### PR TITLE
Performance improvements using Struct.Equals rather than Struct Op_Equals

### DIFF
--- a/AnnoDesigner.Core/Models/AnnoObject.cs
+++ b/AnnoDesigner.Core/Models/AnnoObject.cs
@@ -119,14 +119,5 @@ namespace AnnoDesigner.Core.Models
         /// </summary>
         [DataMember(Order = 11)]
         public bool PavedStreet { get; set; }
-
-        ///// <summary>
-        ///// Localization string
-        ///// </summary>
-        //[DataMember]
-        //public string[] Localization { get; set; }
-
-        //[DataMember]
-        //public SerializableDictionary<int> BuildCosts { get; set; }
     }
 }

--- a/AnnoDesigner/model/LayoutObject.cs
+++ b/AnnoDesigner/model/LayoutObject.cs
@@ -68,7 +68,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_transparentColor == null)
+                if (_transparentColor.Equals(default))
                 {
                     var tmp = WrappedAnnoObject.Color.MediaColor;
                     tmp.A = 128;
@@ -101,7 +101,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_renderColor == null)
+                if (_renderColor.Equals(default))
                 {
                     _renderColor = WrappedAnnoObject.Color.MediaColor;
                 }
@@ -167,7 +167,7 @@ namespace AnnoDesigner.model
         /// </summary>
         public Rect CalculateScreenRect(int gridSize)
         {
-            if (_gridSizeScreenRect != gridSize)
+            if (!_gridSizeScreenRect.Equals(gridSize))
             {
                 _gridSizeScreenRect = gridSize;
                 _screenRect = default;

--- a/AnnoDesigner/model/LayoutObject.cs
+++ b/AnnoDesigner/model/LayoutObject.cs
@@ -145,7 +145,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_position == default)
+                if (_position.Equals(default))
                 {
                     _position = WrappedAnnoObject.Position;
                 }
@@ -180,7 +180,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_screenRect == default)
+                if (_screenRect.Equals(default))
                 {
                     _screenRect = new Rect(_coordinateHelper.GridToScreen(Position, _gridSizeScreenRect), _coordinateHelper.GridToScreen(Size, _gridSizeScreenRect));
                 }
@@ -197,7 +197,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_collisionRect == default)
+                if (_collisionRect.Equals(default))
                 {
                     _collisionRect = new Rect(Position, CollisionSize);
                 }
@@ -210,7 +210,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_collisionSize == default)
+                if (_collisionSize.Equals(default))
                 {
                     _collisionSize = new Size(Size.Width - 0.5, Size.Height - 0.5);
                 }
@@ -254,7 +254,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_size == default)
+                if (_size.Equals(default))
                 {
                     _size = WrappedAnnoObject.Size;
                 }
@@ -302,7 +302,7 @@ namespace AnnoDesigner.model
         {
             var objRect = CalculateScreenRect(gridSize);
 
-            if (_iconRect == default || _gridSizeIconRect != gridSize || _lastScreenRectForIcon != objRect)
+            if (_iconRect.Equals(default) || _gridSizeIconRect != gridSize || _lastScreenRectForIcon != objRect)
             {
                 // draw icon 2x2 grid cells large
                 var minSize = Math.Min(Size.Width, Size.Height);
@@ -336,7 +336,7 @@ namespace AnnoDesigner.model
         {
             var objRect = CalculateScreenRect(gridSize);
 
-            if (_screenRectCenterPoint == default || _lastScreenRectForCenterPoint != objRect)
+            if (_screenRectCenterPoint.Equals(default) || _lastScreenRectForCenterPoint != objRect)
             {
                 _screenRectCenterPoint = _coordinateHelper.GetCenterPoint(objRect);
 
@@ -364,7 +364,7 @@ namespace AnnoDesigner.model
 
         public double GetScreenRadius(int gridSize)
         {
-            if (_screenRadius == default || _lastGridSizeForScreenRadius != gridSize)
+            if (_screenRadius.Equals(default) || _lastGridSizeForScreenRadius != gridSize)
             {
                 _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius, gridSize);
 
@@ -378,7 +378,7 @@ namespace AnnoDesigner.model
         {
             get
             {
-                if (_color == default)
+                if (_color.Equals(default))
                 {
                     _color = WrappedAnnoObject.Color;
                 }


### PR DESCRIPTION
`LayoutObject` is called to many millions of times during the normal use of Anno Designer. In most setters there is a check for `_myPoint == default`. Following on from the below benchmarks, I have updated these getters to use `.Equals()` instead, which should have a small positive impact on performance.

|                  Method |     Mean |     Error |    StdDev |
|------------------------ |---------:|----------:|----------:|
|            Point_Equals | 5.046 ns | 0.1050 ns | 0.0982 ns |
|         Point_Op_Equals | 1.197 ns | 0.0372 ns | 0.0348 ns |
|    Point_Equals_Default | 4.848 ns | 0.0626 ns | 0.0555 ns |
| Point_Op_Equals_Default | 1.138 ns | 0.0172 ns | 0.0144 ns |

Benchmarks run on .Net 4.7.2, comparing 2 different Point structs from the WindowsBase.dll `System.Windows` namespace (the same Point implementation that is used in the code).

The *_Default benchmarks are testing `_myPoint == default` operations.
