### PR TITLE
Fix the issue causing the About page icon to disappear

### DIFF
--- a/AnnoDesigner/About.xaml
+++ b/AnnoDesigner/About.xaml
@@ -29,7 +29,7 @@
             <RowDefinition Height="240*" />
             <RowDefinition Height="110*" />
         </Grid.RowDefinitions>
-        <Image Source="Images/Icons/icon64.png"
+        <Image Source="pack://application:,,,/Images/Icons/icon64.png"
                Stretch="Uniform"
                HorizontalAlignment="Left"
                VerticalAlignment="Top"

--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -6,7 +6,6 @@
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
@@ -64,9 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="icon.ico" />
-    <Content Include="Images\Icons\icon64.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Resource Include="Images\Icons\icon64.png" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Flags\*.png" />


### PR DESCRIPTION
Icon was included as <Content> rather than <Resource>, meaning it looked fine in debug or release modes when run through the IDE, but failed when the build script was ran, as the build script has a specific list of whitelisted files that it copies to the output directory.

This PR fixes that issue.

Also brings up some questions about cleaning up what files we output to the Release directory so we can just zip the entire directory in future - maybe something we could look at in issue #187.