### PR TITLE
always use latetst version of C#

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+   <PropertyGroup>
+      <LangVersion>latest</LangVersion>
+   </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR adds a `Directory.Build.props` so any project uses the latest version of C# available.
See [MSDN](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019) for reference.