### PR TITLE
fixed issues with async update of statistics view

### DIFF
--- a/AnnoDesigner/ViewModels/StatisticsViewModel.cs
+++ b/AnnoDesigner/ViewModels/StatisticsViewModel.cs
@@ -237,7 +237,7 @@ namespace AnnoDesigner.ViewModels
 
             if (mode != UpdateMode.NoBuildingList && ShowBuildingList)
             {
-                var groupedBuildings = placedObjects.GroupBy(_ => _.Identifier).ToList();
+                var groupedPlacedBuildings = placedObjects.GroupBy(_ => _.Identifier).ToList();
 
                 IEnumerable<IGrouping<string, LayoutObject>> groupedSelectedBuildings = null;
                 if (selectedObjects != null && selectedObjects.Count > 0)
@@ -245,7 +245,7 @@ namespace AnnoDesigner.ViewModels
                     groupedSelectedBuildings = selectedObjects.Where(_ => _ != null).GroupBy(_ => _.Identifier).ToList();
                 }
 
-                var buildingsTask = Task.Run(() => GetStatisticBuildings(groupedBuildings, buildingPresets));
+                var buildingsTask = Task.Run(() => GetStatisticBuildings(groupedPlacedBuildings, buildingPresets));
                 var selectedBuildingsTask = Task.Run(() => GetStatisticBuildings(groupedSelectedBuildings, buildingPresets));
                 SelectedBuildings = await selectedBuildingsTask;
                 Buildings = await buildingsTask;

--- a/AnnoDesigner/ViewModels/StatisticsViewModel.cs
+++ b/AnnoDesigner/ViewModels/StatisticsViewModel.cs
@@ -237,8 +237,13 @@ namespace AnnoDesigner.ViewModels
 
             if (mode != UpdateMode.NoBuildingList && ShowBuildingList)
             {
-                var groupedBuildings = placedObjects.GroupBy(_ => _.Identifier);
-                var groupedSelectedBuildings = selectedObjects.Count > 0 ? selectedObjects.GroupBy(_ => _.Identifier) : null;
+                var groupedBuildings = placedObjects.GroupBy(_ => _.Identifier).ToList();
+
+                IEnumerable<IGrouping<string, LayoutObject>> groupedSelectedBuildings = null;
+                if (selectedObjects != null && selectedObjects.Count > 0)
+                {
+                    groupedSelectedBuildings = selectedObjects.Where(_ => _ != null).GroupBy(_ => _.Identifier).ToList();
+                }
 
                 var buildingsTask = Task.Run(() => GetStatisticBuildings(groupedBuildings, buildingPresets));
                 var selectedBuildingsTask = Task.Run(() => GetStatisticBuildings(groupedSelectedBuildings, buildingPresets));
@@ -256,7 +261,7 @@ namespace AnnoDesigner.ViewModels
 
         private ObservableCollection<StatisticsBuilding> GetStatisticBuildings(IEnumerable<IGrouping<string, LayoutObject>> groupedBuildingsByIdentifier, BuildingPresets buildingPresets)
         {
-            if (groupedBuildingsByIdentifier == null)
+            if (groupedBuildingsByIdentifier is null || !groupedBuildingsByIdentifier.Any())
             {
                 return new ObservableCollection<StatisticsBuilding>();
             }


### PR DESCRIPTION
This PR fixes some issues I encountered with the statistics view when it is updated async.
Sometimes a collection was modified or an element in the collection was null.
Most of the time the error occured when closing the app.