### PR TITLE
DragAll: Do not place building if right click was before left click

### DIFF
--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -1206,7 +1206,7 @@ namespace AnnoDesigner
             HandleMouse(e);
 
             // check if user begins to drag
-            if (Math.Abs(_mouseDragStart.X - _mousePosition.X) > 1 || Math.Abs(_mouseDragStart.Y - _mousePosition.Y) > 1)
+            if (Math.Abs(_mouseDragStart.X - _mousePosition.X) >= 1 || Math.Abs(_mouseDragStart.Y - _mousePosition.Y) >= 1)
             {
                 switch (CurrentMode)
                 {


### PR DESCRIPTION
This PR fixes a behaviour which annoyed me.
You can drag the whole layout by pressing both mouse buttons (left and right). But if you have a building "on your cursor" it was always placed, when the right button was pressed before the left button.
This is fixed now.

If you like the current behaviour, just close this PR.

#### Before this PR

- place some buildings
- select a building so that it "sticks to the cursor"
- press right mouse button (no release)
- press left mouse button (no release)
- move mouse
-> building is placed

![master](https://user-images.githubusercontent.com/6222752/84481622-a2863e00-ac96-11ea-8ce8-fb490a8e3178.gif)

#### After this PR

- place some buildings
- select a building so that it "sticks to the cursor"
- press right mouse button (no release)
- press left mouse button (no release)
- move mouse
-> building is **not** placed

![PR](https://user-images.githubusercontent.com/6222752/84481630-a5812e80-ac96-11ea-856d-23671d800f56.gif)
