### PR TITLE
First pass at undo and redo logic

### DIFF
--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -122,20 +122,20 @@ namespace AnnoDesigner
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
         private List<LayoutObject> _placedObjects;
-        private List<IAction> _previousActions;
-        private List<IAction> _futureActions;
+        private Stack<IAction> _previousActions;
+        private Stack<IAction> _futureActions;
 
         public ActionManager(ref List<LayoutObject> placedObjects){
             _placedObjects = placedObjects;
-            _previousActions = new List<IAction>();
-            _futureActions = new List<IAction>();
+            _previousActions = new Stack<IAction>();
+            _futureActions = new Stack<IAction>();
         }
 
         public void PerformAction(IAction action){
             // Performing a new action so clear all future actions as they are no longer valid.
             logger.Warn("Performing action");
             _futureActions.Clear();
-            _previousActions.Add(action);
+            _previousActions.Push(action);
             action.PerformAction(_placedObjects);
         }
 
@@ -146,9 +146,8 @@ namespace AnnoDesigner
                 logger.Warn("No actions to undo");
                 return;
             }
-            IAction actionToUndo = _previousActions[_previousActions.Count - 1];
-            _previousActions.RemoveAt(_previousActions.Count - 1);
-            _futureActions.Add(actionToUndo);
+            IAction actionToUndo = _previousActions.Pop();
+            _futureActions.Push(actionToUndo);
             actionToUndo.UndoAction(_placedObjects);
         }
 
@@ -159,9 +158,8 @@ namespace AnnoDesigner
                 logger.Warn("No actions to redo");
                 return;
             }
-            IAction actionToRedo = _futureActions[_futureActions.Count - 1];
-            _futureActions.RemoveAt(_futureActions.Count - 1);
-            _previousActions.Add(actionToRedo);
+            IAction actionToRedo = _futureActions.Pop();
+            _previousActions.Push(actionToRedo);
             actionToRedo.PerformAction(_placedObjects);
         }
     }


### PR DESCRIPTION
I've had a first pass at implementing undo/redo logic. It works on the principle that all modifications to the "placed objects" on the canvas should be defined by classes which can undo their modifications. They can then be stored on a previous actions queue and popped off and undone when required.

There are a bunch of things I'm not happy with/would improve:
* The naming in general is pretty poor. I particularly dislike class "Managers" as a rule but haven't bothered thinking of something better yet.
* Code organisation, currently just wacked it in an existing file. However, this would not be the long-term living place for the actions/action queue.
* At the moment it only covers adding/removing objects from the canvas. Moving objects will break the functionality (as I imagine will a load of other things).
* Code formatting/style, I'm unsure of things like when I should be using underscores/capital letters in variable/method names etc. 

Important thing is that the undo/redo functionality does work for adding/removing objects. Use `Ctrl` + `Z` for undo and `Ctrl` + `Shift` + `Z` or `Ctrl` + `Y` for redo.

However, if you think this is solid in principle then I'll happily attempt to fix as much of the above as I can.