### PR TITLE
Add image to language menu items

### DIFF
--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -62,8 +62,6 @@
                   Grid.ColumnSpan="3">
                 <Menu.Resources>
                     <Style TargetType="{x:Type MenuItem}">
-                        <!--<Setter Property="Foreground"
-                            Value="Black" />-->
                         <Style.Triggers>
                             <Trigger Property="IsEnabled"
                                      Value="False">
@@ -126,8 +124,15 @@
                 <MenuItem Header="{l:Localize Language}"
                           TabIndex="23"
                           ItemsSource="{Binding Languages}">
+                    <MenuItem.Resources>
+                        <Image x:Key="flagImage"
+                               Source="{Binding FlagPath}"
+                               x:Shared="False" />
+                    </MenuItem.Resources>
                     <MenuItem.ItemContainerStyle>
                         <Style TargetType="MenuItem">
+                            <Setter Property="Icon"
+                                    Value="{StaticResource flagImage}" />
                             <Setter Property="Header"
                                     Value="{Binding Name}" />
                             <Setter Property="IsCheckable"


### PR DESCRIPTION
This PR adds the corresponding images to the menu `Language` menu item.

![languages](https://user-images.githubusercontent.com/6222752/87153649-1a588000-c2b8-11ea-860d-32e1b1aa089e.png)
