### PR TITLE
Add service to abstract MessageBoxes

### DIFF
--- a/AnnoDesigner.Core/Extensions/MessageBoxServiceExtensions.cs
+++ b/AnnoDesigner.Core/Extensions/MessageBoxServiceExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using AnnoDesigner.Core.Services;
+
+namespace AnnoDesigner.Core.Extensions
+{
+    public static class MessageBoxServiceExtensions
+    {
+        public static void ShowMessage(this IMessageBoxService service, string message, string title)
+        {
+            if (service == null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            service.ShowMessage(null, message, title);
+        }
+
+        public static void ShowWarning(this IMessageBoxService service, string message, string title)
+        {
+            if (service == null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            service.ShowWarning(null, message, title);
+        }
+
+        public static void ShowError(this IMessageBoxService service, string message, string title)
+        {
+            if (service == null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            service.ShowError(null, message, title);
+        }
+
+        public static bool ShowQuestion(this IMessageBoxService service, string message, string title)
+        {
+            if (service == null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            return service.ShowQuestion(null, message, title);
+        }
+    }
+}

--- a/AnnoDesigner.Core/Extensions/MessageBoxServiceExtensions.cs
+++ b/AnnoDesigner.Core/Extensions/MessageBoxServiceExtensions.cs
@@ -5,12 +5,7 @@ namespace AnnoDesigner.Core.Extensions
 {
     public static class MessageBoxServiceExtensions
     {
-        public static void ShowMessage(this IMessageBoxService service, string message)
-        {
-            ShowMessage(service, message, "Information");
-        }
-
-        public static void ShowMessage(this IMessageBoxService service, string message, string title)
+        public static void ShowMessage(this IMessageBoxService service, string message, string title = "Information")
         {
             if (service == null)
             {
@@ -20,12 +15,7 @@ namespace AnnoDesigner.Core.Extensions
             service.ShowMessage(null, message, title);
         }
 
-        public static void ShowWarning(this IMessageBoxService service, string message)
-        {
-            ShowWarning(service, message, "Warning");
-        }
-
-        public static void ShowWarning(this IMessageBoxService service, string message, string title)
+        public static void ShowWarning(this IMessageBoxService service, string message, string title = "Warning")
         {
             if (service == null)
             {
@@ -35,12 +25,7 @@ namespace AnnoDesigner.Core.Extensions
             service.ShowWarning(null, message, title);
         }
 
-        public static void ShowError(this IMessageBoxService service, string message)
-        {
-            ShowError(service, message, "Error");
-        }
-
-        public static void ShowError(this IMessageBoxService service, string message, string title)
+        public static void ShowError(this IMessageBoxService service, string message, string title = "Error")
         {
             if (service == null)
             {
@@ -50,12 +35,8 @@ namespace AnnoDesigner.Core.Extensions
             service.ShowError(null, message, title);
         }
 
-        public static void ShowQuestion(this IMessageBoxService service, string message)
-        {
-            ShowQuestion(service, message, "Question");
-        }
 
-        public static bool ShowQuestion(this IMessageBoxService service, string message, string title)
+        public static bool ShowQuestion(this IMessageBoxService service, string message, string title = "Question")
         {
             if (service == null)
             {

--- a/AnnoDesigner.Core/Extensions/MessageBoxServiceExtensions.cs
+++ b/AnnoDesigner.Core/Extensions/MessageBoxServiceExtensions.cs
@@ -5,6 +5,11 @@ namespace AnnoDesigner.Core.Extensions
 {
     public static class MessageBoxServiceExtensions
     {
+        public static void ShowMessage(this IMessageBoxService service, string message)
+        {
+            ShowMessage(service, message, "Information");
+        }
+
         public static void ShowMessage(this IMessageBoxService service, string message, string title)
         {
             if (service == null)
@@ -13,6 +18,11 @@ namespace AnnoDesigner.Core.Extensions
             }
 
             service.ShowMessage(null, message, title);
+        }
+
+        public static void ShowWarning(this IMessageBoxService service, string message)
+        {
+            ShowWarning(service, message, "Warning");
         }
 
         public static void ShowWarning(this IMessageBoxService service, string message, string title)
@@ -25,6 +35,11 @@ namespace AnnoDesigner.Core.Extensions
             service.ShowWarning(null, message, title);
         }
 
+        public static void ShowError(this IMessageBoxService service, string message)
+        {
+            ShowError(service, message, "Error");
+        }
+
         public static void ShowError(this IMessageBoxService service, string message, string title)
         {
             if (service == null)
@@ -33,6 +48,11 @@ namespace AnnoDesigner.Core.Extensions
             }
 
             service.ShowError(null, message, title);
+        }
+
+        public static void ShowQuestion(this IMessageBoxService service, string message)
+        {
+            ShowQuestion(service, message, "Question");
         }
 
         public static bool ShowQuestion(this IMessageBoxService service, string message, string title)

--- a/AnnoDesigner.Core/Services/IMessageBoxService.cs
+++ b/AnnoDesigner.Core/Services/IMessageBoxService.cs
@@ -1,0 +1,13 @@
+﻿namespace AnnoDesigner.Core.Services
+{
+    public interface IMessageBoxService
+    {
+        void ShowMessage(object owner, string message, string title);
+
+        void ShowWarning(object owner, string message, string title);
+
+        void ShowError(object owner, string message, string title);
+
+        bool ShowQuestion(object owner, string message, string title);
+    }
+}

--- a/AnnoDesigner/App.xaml.cs
+++ b/AnnoDesigner/App.xaml.cs
@@ -74,7 +74,7 @@ namespace AnnoDesigner
                 }
             }
 
-            _messageBoxService.ShowError(message, "Error");
+            _messageBoxService.ShowError(message);
 
             Environment.Exit(-1);
         }
@@ -127,7 +127,7 @@ namespace AnnoDesigner
 
                         if (!createdNewMutex)
                         {
-                            _messageBoxService.ShowMessage("Another instance of the app is already running.", string.Empty);
+                            _messageBoxService.ShowMessage("Another instance of the app is already running.");
                             Environment.Exit(-1);
                         }
                     }
@@ -154,7 +154,7 @@ namespace AnnoDesigner
                 {
                     logger.Error(ex, "Error upgrading settings.");
 
-                    _messageBoxService.ShowError("The settings file has become corrupted. We must reset your settings.", "Error");
+                    _messageBoxService.ShowError("The settings file has become corrupted. We must reset your settings.");
 
                     var fileName = "";
                     if (!string.IsNullOrEmpty(ex.Filename))

--- a/AnnoDesigner/App.xaml.cs
+++ b/AnnoDesigner/App.xaml.cs
@@ -1,17 +1,18 @@
 ﻿using System;
 using System.Configuration;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
-using System.IO.Abstractions.TestingHelpers;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using AnnoDesigner.Core.Extensions;
 using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.Models;
 using AnnoDesigner.Core.RecentFiles;
+using AnnoDesigner.Core.Services;
 using AnnoDesigner.Models;
+using AnnoDesigner.Services;
 using AnnoDesigner.ViewModels;
 using NLog;
 using NLog.Targets;
@@ -26,11 +27,13 @@ namespace AnnoDesigner
         private static readonly ICommons _commons;
         private static readonly IAppSettings _appSettings;
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+        private static readonly IMessageBoxService _messageBoxService;
 
         static App()
         {
             _commons = Commons.Instance;
             _appSettings = new AppSettings();
+            _messageBoxService = new MessageBoxService();
         }
 
         public App()
@@ -71,7 +74,7 @@ namespace AnnoDesigner
                 }
             }
 
-            MessageBox.Show(message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            _messageBoxService.ShowError(message, "Error");
 
             Environment.Exit(-1);
         }
@@ -124,7 +127,7 @@ namespace AnnoDesigner
 
                         if (!createdNewMutex)
                         {
-                            MessageBox.Show("Another instance of the app is already running.");
+                            _messageBoxService.ShowMessage("Another instance of the app is already running.", string.Empty);
                             Environment.Exit(-1);
                         }
                     }
@@ -151,10 +154,7 @@ namespace AnnoDesigner
                 {
                     logger.Error(ex, "Error upgrading settings.");
 
-                    MessageBox.Show("The settings file has become corrupted. We must reset your settings.",
-                          "Error",
-                          MessageBoxButton.OK,
-                          MessageBoxImage.Error);
+                    _messageBoxService.ShowError("The settings file has become corrupted. We must reset your settings.", "Error");
 
                     var fileName = "";
                     if (!string.IsNullOrEmpty(ex.Filename))
@@ -186,7 +186,7 @@ namespace AnnoDesigner
                 var serializer = new RecentFilesAppSettingsSerializer(_appSettings);
 
                 IRecentFilesHelper recentFilesHelper = new RecentFilesHelper(serializer, new FileSystem());
-                var mainVM = new MainViewModel(_commons, _appSettings, recentFilesHelper);
+                var mainVM = new MainViewModel(_commons, _appSettings, recentFilesHelper, _messageBoxService);
 
                 //TODO MainWindow.ctor calls AnnoCanvas.ctor loads presets -> change logic when to load data 
                 MainWindow = new MainWindow();

--- a/AnnoDesigner/Commons.cs
+++ b/AnnoDesigner/Commons.cs
@@ -1,12 +1,9 @@
-﻿using AnnoDesigner.Models;
-using NLog;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using AnnoDesigner.Models;
+using AnnoDesigner.Services;
+using NLog;
 
 namespace AnnoDesigner
 {
@@ -29,7 +26,7 @@ namespace AnnoDesigner
 
         static Commons()
         {
-            _updateHelper = new UpdateHelper(App.ApplicationPath, new AppSettings());
+            _updateHelper = new UpdateHelper(App.ApplicationPath, new AppSettings(), new MessageBoxService());
         }
 
         private Commons()

--- a/AnnoDesigner/PreferencesWindow.xaml.cs
+++ b/AnnoDesigner/PreferencesWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Collections.ObjectModel;
 using AnnoDesigner.ViewModels;
 using AnnoDesigner.PreferencesPages;
 using AnnoDesigner.Models;
+using AnnoDesigner.Core.Services;
 
 namespace AnnoDesigner
 {
@@ -25,10 +26,13 @@ namespace AnnoDesigner
     /// </summary>
     public partial class PreferencesWindow : Window
     {
-        public PreferencesWindow(IAppSettings appSettings, ICommons commons, HotkeyCommandManager commandManager)
+        public PreferencesWindow(IAppSettings appSettings,
+            ICommons commons,
+            HotkeyCommandManager commandManager,
+            IMessageBoxService messageBoxServiceToUse)
         {
             InitializeComponent();
-            DataContext = new PreferencesViewModel(appSettings, commons, commandManager, CurrentPage.NavigationService);
+            DataContext = new PreferencesViewModel(appSettings, commons, commandManager, CurrentPage.NavigationService, messageBoxServiceToUse);
             Loaded += Preferences_Loaded;
         }
 

--- a/AnnoDesigner/Services/MessageBoxService.cs
+++ b/AnnoDesigner/Services/MessageBoxService.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using AnnoDesigner.Core.Services;
+using MessageBox = Xceed.Wpf.Toolkit.MessageBox;
+
+namespace AnnoDesigner.Services
+{
+    public class MessageBoxService : IMessageBoxService
+    {
+        public void ShowMessage(object owner, string message, string title)
+        {
+            if (owner is Window ownerWindow)
+            {
+                MessageBox.Show(ownerWindow,
+                    message,
+                    title,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            else
+            {
+                MessageBox.Show(message,
+                    title,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+        }
+
+        public void ShowWarning(object owner, string message, string title)
+        {
+            if (owner is Window ownerWindow)
+            {
+                MessageBox.Show(ownerWindow,
+                    message,
+                    title,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+            else
+            {
+                MessageBox.Show(message,
+                    title,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+        }
+
+        public void ShowError(object owner, string message, string title)
+        {
+            if (owner is Window ownerWindow)
+            {
+                MessageBox.Show(ownerWindow,
+                    message,
+                    title,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            else
+            {
+                MessageBox.Show(message,
+                    title,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+        }
+
+        public bool ShowQuestion(object owner, string message, string title)
+        {
+            MessageBoxResult result;
+
+            if (owner is Window ownerWindow)
+            {
+                result = MessageBox.Show(ownerWindow,
+                    message,
+                    title,
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Question);
+            }
+            else
+            {
+                result = MessageBox.Show(message,
+                    title,
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Question);
+            }
+
+            return result == MessageBoxResult.Yes;
+        }
+    }
+}

--- a/AnnoDesigner/UpdateHelper.cs
+++ b/AnnoDesigner/UpdateHelper.cs
@@ -1,11 +1,4 @@
-﻿using AnnoDesigner.Core;
-using AnnoDesigner.Core.Helper;
-using AnnoDesigner.Core.Models;
-using AnnoDesigner.Models;
-using AnnoDesigner.Properties;
-using NLog;
-using Octokit;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -15,7 +8,14 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using System.Windows;
+using AnnoDesigner.Core;
+using AnnoDesigner.Core.Extensions;
+using AnnoDesigner.Core.Helper;
+using AnnoDesigner.Core.Models;
+using AnnoDesigner.Core.Services;
+using AnnoDesigner.Models;
+using NLog;
+using Octokit;
 
 namespace AnnoDesigner
 {
@@ -35,6 +35,7 @@ namespace AnnoDesigner
         private HttpClient _httpClient;
         private readonly string _basePath;
         private readonly IAppSettings _appSettings;
+        private readonly IMessageBoxService _messageBoxService;
 
         /// <summary>
         /// Initializes a new instance of <see cref="AnnoDesigner.UpdateHelper"./>
@@ -43,10 +44,13 @@ namespace AnnoDesigner
         /// <remarks>
         /// example to get the basePath: <c>string basePath = AppDomain.CurrentDomain.BaseDirectory;</c>
         /// </remarks>
-        public UpdateHelper(string basePathToUse, IAppSettings appSettingsToUse)
+        public UpdateHelper(string basePathToUse,
+            IAppSettings appSettingsToUse,
+            IMessageBoxService messageBoxServiceToUse)
         {
             _basePath = basePathToUse;
             _appSettings = appSettingsToUse;
+            _messageBoxService = messageBoxServiceToUse;
         }
 
         private GitHubClient ApiClient
@@ -284,11 +288,8 @@ namespace AnnoDesigner
             {
                 logger.Error(ex, "Error replacing updated presets file.");
 
-                MessageBox.Show(Localization.Localization.Translations["UpdateErrorPresetMessage"],
-                            Localization.Localization.Translations["Error"],
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Error,
-                            MessageBoxResult.OK);
+                _messageBoxService.ShowError(Localization.Localization.Translations["UpdateErrorPresetMessage"],
+                            Localization.Localization.Translations["Error"]);
             }
         }
 
@@ -302,10 +303,8 @@ namespace AnnoDesigner
                 {
                     logger.Info("Could not establish a connection to the internet.");
 
-                    MessageBox.Show(Localization.Localization.Translations["UpdateNoConnectionMessage"],
-                        Localization.Localization.Translations["Error"],
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Warning);
+                    _messageBoxService.ShowError(Localization.Localization.Translations["UpdateNoConnectionMessage"],
+                            Localization.Localization.Translations["Error"]);
 
                     return null;
                 }

--- a/AnnoDesigner/ViewModels/BuildingSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/BuildingSettingsViewModel.cs
@@ -1,16 +1,15 @@
-using AnnoDesigner.Core.Models;
-using AnnoDesigner.Core.Presets.Helper;
-using AnnoDesigner.Core.Presets.Models;
-using AnnoDesigner.Models;
-using AnnoDesigner.Properties;
-using NLog;
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows.Input;
 using System.Windows.Media;
-using Xceed.Wpf.Toolkit;
+using AnnoDesigner.Core.Extensions;
+using AnnoDesigner.Core.Models;
+using AnnoDesigner.Core.Presets.Helper;
+using AnnoDesigner.Core.Presets.Models;
+using AnnoDesigner.Core.Services;
+using AnnoDesigner.Models;
+using NLog;
 
 namespace AnnoDesigner.ViewModels
 {
@@ -19,6 +18,7 @@ namespace AnnoDesigner.ViewModels
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
         private readonly IAppSettings _appSettings;
+        private readonly IMessageBoxService _messageBoxService;
 
         private Color? _selectedColor;
         private int _buildingHeight;
@@ -43,9 +43,10 @@ namespace AnnoDesigner.ViewModels
         /// <summary>
         /// only used for databinding
         /// </summary>
-        public BuildingSettingsViewModel(IAppSettings appSettingsToUse)
+        public BuildingSettingsViewModel(IAppSettings appSettingsToUse, IMessageBoxService messageBoxServiceToUse)
         {
             _appSettings = appSettingsToUse;
+            _messageBoxService = messageBoxServiceToUse;
 
             ApplyColorToSelectionCommand = new RelayCommand(ApplyColorToSelection, CanApplyColorToSelection);
             ApplyPredefinedColorToSelectionCommand = new RelayCommand(ApplyPredefinedColorToSelection, CanApplyPredefinedColorToSelection);
@@ -268,8 +269,7 @@ namespace AnnoDesigner.ViewModels
         {
             if (!_appSettings.ShowPavedRoadsWarning)
             {
-                MessageBox.Show(
-                    Localization.Localization.Translations["PavedStreetToolTip"],
+                _messageBoxService.ShowMessage(Localization.Localization.Translations["PavedStreetToolTip"],
                     Localization.Localization.Translations["PavedStreetWarningTitle"]);
                 _appSettings.ShowPavedRoadsWarning = true;
             }

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -108,7 +108,7 @@ namespace AnnoDesigner.ViewModels
             StatisticsViewModel.IsVisible = _appSettings.StatsShowStats;
             StatisticsViewModel.ShowStatisticsBuildingCount = _appSettings.StatsShowBuildingCount;
 
-            BuildingSettingsViewModel = new BuildingSettingsViewModel(_appSettings);
+            BuildingSettingsViewModel = new BuildingSettingsViewModel(_appSettings, _messageBoxService);
 
             PresetsTreeViewModel = new PresetsTreeViewModel(new TreeLocalization(_commons), _commons);
             PresetsTreeViewModel.ApplySelectedItem += PresetTreeViewModel_ApplySelectedItem;
@@ -1225,7 +1225,7 @@ namespace AnnoDesigner.ViewModels
                 }
 
                 // initialize output canvas
-                var target = new AnnoCanvas(AnnoCanvas.BuildingPresets, icons, _coordinateHelper, _brushCache, _penCache)
+                var target = new AnnoCanvas(AnnoCanvas.BuildingPresets, icons, _coordinateHelper, _brushCache, _penCache, _messageBoxService)
                 {
                     PlacedObjects = allObjects,
                     RenderGrid = AnnoCanvas.RenderGrid,
@@ -1428,7 +1428,7 @@ namespace AnnoDesigner.ViewModels
 
         private void ExecuteShowPreferencesWindow(object param)
         {
-            var preferencesWindow = new PreferencesWindow(_appSettings, _commons, HotkeyCommandManager)
+            var preferencesWindow = new PreferencesWindow(_appSettings, _commons, HotkeyCommandManager, _messageBoxService)
             {
                 Owner = Application.Current.MainWindow,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -21,13 +21,13 @@ using AnnoDesigner.Core.Layout.Exceptions;
 using AnnoDesigner.Core.Layout.Models;
 using AnnoDesigner.Core.Models;
 using AnnoDesigner.Core.Presets.Helper;
+using AnnoDesigner.Core.Services;
 using AnnoDesigner.CustomEventArgs;
 using AnnoDesigner.Helper;
 using AnnoDesigner.Localization;
 using AnnoDesigner.Models;
 using Microsoft.Win32;
 using NLog;
-using MessageBox = Xceed.Wpf.Toolkit.MessageBox;
 
 namespace AnnoDesigner.ViewModels
 {
@@ -42,6 +42,7 @@ namespace AnnoDesigner.ViewModels
         private readonly IBrushCache _brushCache;
         private readonly IPenCache _penCache;
         private readonly IRecentFilesHelper _recentFilesHelper;
+        private readonly IMessageBoxService _messageBoxService;
 
         public event EventHandler<EventArgs> ShowStatisticsChanged;
 
@@ -82,6 +83,7 @@ namespace AnnoDesigner.ViewModels
         public MainViewModel(ICommons commonsToUse,
             IAppSettings appSettingsToUse,
             IRecentFilesHelper recentFilesHelperToUse,
+            IMessageBoxService messageBoxServiceToUse,
             ILayoutLoader layoutLoaderToUse = null,
             ICoordinateHelper coordinateHelperToUse = null,
             IBrushCache brushCacheToUse = null,
@@ -92,6 +94,7 @@ namespace AnnoDesigner.ViewModels
 
             _appSettings = appSettingsToUse;
             _recentFilesHelper = recentFilesHelperToUse;
+            _messageBoxService = messageBoxServiceToUse;
 
             _layoutLoader = layoutLoaderToUse ?? new LayoutLoader();
             _coordinateHelper = coordinateHelperToUse ?? new CoordinateHelper();
@@ -281,7 +284,8 @@ namespace AnnoDesigner.ViewModels
             catch (Exception ex)
             {
                 logger.Error(ex, "Error applying preset.");
-                MessageBox.Show("Something went wrong while applying the preset.");
+                _messageBoxService.ShowError("Something went wrong while applying the preset.",
+                   Localization.Localization.Translations["Error"]);
             }
         }
 
@@ -517,7 +521,7 @@ namespace AnnoDesigner.ViewModels
                 catch (Exception ex)
                 {
                     logger.Error(ex, "Error checking version.");
-                    MessageBox.Show("Error checking version. \n\nAdded more information to log.", "Version check failed");
+                    _messageBoxService.ShowError("Error checking version. \n\nAdded more information to log.", "Version check failed");
                     return;
                 }
             }
@@ -536,11 +540,8 @@ namespace AnnoDesigner.ViewModels
                 if (double.Parse(dowloadedContent, CultureInfo.InvariantCulture) > Constants.Version)
                 {
                     // new version found
-                    if (MessageBox.Show("A newer version was found, do you want to visit the releases page?\nhttps://github.com/AnnoDesigner/anno-designer/releases\n\n Clicking 'Yes' will open a new tab in your web browser.",
-                        "Update available",
-                        MessageBoxButton.YesNo,
-                        MessageBoxImage.Asterisk,
-                        MessageBoxResult.OK) == MessageBoxResult.Yes)
+                    if (_messageBoxService.ShowQuestion("A newer version was found, do you want to visit the releases page?\nhttps://github.com/AgmasGold/anno-designer/releases\n\n Clicking 'Yes' will open a new tab in your web browser.",
+                        "Update available"))
                     {
                         Process.Start("https://github.com/AnnoDesigner/anno-designer/releases");
                     }
@@ -551,7 +552,8 @@ namespace AnnoDesigner.ViewModels
 
                     if (forcedCheck)
                     {
-                        MessageBox.Show("This version is up to date.", "No updates found");
+                        _messageBoxService.ShowMessage("This version is up to date.",
+                            "No updates found");
                     }
                 }
 
@@ -560,7 +562,8 @@ namespace AnnoDesigner.ViewModels
                 {
                     _appSettings.PromptedForAutoUpdateCheck = true;
 
-                    if (MessageBox.Show("Do you want to continue checking for a new version on startup?\n\nThis option can be changed from the help menu.", "Continue checking for updates?", MessageBoxButton.YesNo, MessageBoxImage.Information) == MessageBoxResult.No)
+                    if (_messageBoxService.ShowQuestion("Do you want to continue checking for a new version on startup?\n\nThis option can be changed from the help menu.",
+                        "Continue checking for updates?"))
                     {
                         AutomaticUpdateCheck = false;
                     }
@@ -569,10 +572,8 @@ namespace AnnoDesigner.ViewModels
             catch (Exception ex)
             {
                 logger.Error(ex, "Error checking version.");
-                MessageBox.Show($"Error checking version.{Environment.NewLine}{Environment.NewLine}More information is found in the log.",
-                    "Version check failed",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Error);
+                _messageBoxService.ShowError($"Error checking version.{Environment.NewLine}{Environment.NewLine}More information is found in the log.",
+                   "Version check failed");
                 return;
             }
         }
@@ -588,11 +589,8 @@ namespace AnnoDesigner.ViewModels
             var isNewReleaseAvailable = foundRelease.Version > new Version(AnnoCanvas.BuildingPresets.Version);
             if (isNewReleaseAvailable)
             {
-                if (MessageBox.Show(Localization.Localization.Translations["UpdateAvailablePresetMessage"],
-                    Localization.Localization.Translations["UpdateAvailableHeader"],
-                    MessageBoxButton.YesNo,
-                    MessageBoxImage.Asterisk,
-                    MessageBoxResult.OK) == MessageBoxResult.Yes)
+                if (_messageBoxService.ShowQuestion(Localization.Localization.Translations["UpdateAvailablePresetMessage"],
+                    Localization.Localization.Translations["UpdateAvailableHeader"]))
                 {
                     IsBusy = true;
 
@@ -601,20 +599,15 @@ namespace AnnoDesigner.ViewModels
                         //already asked for admin rights?
                         if (Environment.GetCommandLineArgs().Any(x => x.Trim().Equals(Constants.Argument_Ask_For_Admin, StringComparison.OrdinalIgnoreCase)))
                         {
-                            MessageBox.Show($"You have no write access to the folder.{Environment.NewLine}The update can not be installed.",
-                                Localization.Localization.Translations["Error"],
-                                MessageBoxButton.OK,
-                                MessageBoxImage.Warning);
+                            _messageBoxService.ShowWarning($"You have no write access to the folder.{Environment.NewLine}The update can not be installed.",
+                                  Localization.Localization.Translations["Error"]);
 
                             IsBusy = false;
                             return;
                         }
 
-                        MessageBox.Show(Localization.Localization.Translations["UpdateRequiresAdminRightsMessage"],
-                            Localization.Localization.Translations["AdminRightsRequired"],
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Information,
-                            MessageBoxResult.OK);
+                        _messageBoxService.ShowMessage(Localization.Localization.Translations["UpdateRequiresAdminRightsMessage"],
+                            Localization.Localization.Translations["AdminRightsRequired"]);
 
                         Commons.RestartApplication(true, Constants.Argument_Ask_For_Admin, App.ExecutablePath);
                     }
@@ -1102,9 +1095,8 @@ namespace AnnoDesigner.ViewModels
             {
                 logger.Warn(layoutEx, "Version of layout does not match.");
 
-                if (MessageBox.Show(
-                        "Try loading anyway?\nThis is very likely to fail or result in strange things happening.",
-                        "File version mismatch", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                if (_messageBoxService.ShowQuestion("Try loading anyway?\nThis is very likely to fail or result in strange things happening.",
+                        "File version mismatch"))
                 {
                     ExecuteLoadLayoutFromJsonSub(jsonString, true);
                 }
@@ -1112,10 +1104,8 @@ namespace AnnoDesigner.ViewModels
             catch (Exception ex)
             {
                 logger.Error(ex, "Error loading layout from JSON.");
-                MessageBox.Show("Something went wrong while loading the layout.",
-                        Localization.Localization.Translations["Error"],
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Error);
+                _messageBoxService.ShowError("Something went wrong while loading the layout.",
+                        Localization.Localization.Translations["Error"]);
             }
         }
 
@@ -1151,10 +1141,7 @@ namespace AnnoDesigner.ViewModels
         {
             var message = isDeregistration ? Localization.Localization.Translations["UnregisterFileExtensionSuccessful"] : Localization.Localization.Translations["RegisterFileExtensionSuccessful"];
 
-            MessageBox.Show(message,
-                Localization.Localization.Translations["Successful"],
-                MessageBoxButton.OK,
-                MessageBoxImage.Information);
+            _messageBoxService.ShowMessage(message, Localization.Localization.Translations["Successful"]);
         }
 
         public ICommand ExportImageCommand { get; private set; }
@@ -1189,20 +1176,16 @@ namespace AnnoDesigner.ViewModels
                 {
                     RenderToFile(dialog.FileName, 1, exportZoom, exportSelection, StatisticsViewModel.IsVisible);
 
-                    MessageBox.Show(Application.Current.MainWindow,
-                        Localization.Localization.Translations["ExportImageSuccessful"],
-                        Localization.Localization.Translations["Successful"],
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Information);
+                    _messageBoxService.ShowMessage(Application.Current.MainWindow,
+                       Localization.Localization.Translations["ExportImageSuccessful"],
+                       Localization.Localization.Translations["Successful"]);
                 }
                 catch (Exception ex)
                 {
                     logger.Error(ex, "Error exporting image.");
-                    MessageBox.Show(Application.Current.MainWindow,
+                    _messageBoxService.ShowError(Application.Current.MainWindow,
                         "Something went wrong while exporting the image.",
-                        Localization.Localization.Translations["Error"],
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Error);
+                        Localization.Localization.Translations["Error"]);
                 }
             }
         }
@@ -1341,17 +1324,14 @@ namespace AnnoDesigner.ViewModels
 
                     Clipboard.SetText(jsonString, TextDataFormat.UnicodeText);
 
-                    MessageBox.Show(Localization.Localization.Translations["ClipboardContainsLayoutAsJson"],
-                        Localization.Localization.Translations["Successful"],
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Information,
-                        MessageBoxResult.OK);
+                    _messageBoxService.ShowMessage(Localization.Localization.Translations["ClipboardContainsLayoutAsJson"],
+                        Localization.Localization.Translations["Successful"]);
                 }
             }
             catch (Exception ex)
             {
                 logger.Error(ex, "Error saving layout to JSON.");
-                MessageBox.Show(ex.Message, "Something went wrong while saving the layout.");
+                _messageBoxService.ShowError(ex.Message, "Something went wrong while saving the layout.");
             }
         }
 
@@ -1439,7 +1419,8 @@ namespace AnnoDesigner.ViewModels
             }
             catch (Exception)
             {
-                MessageBox.Show("Error: Invalid building configuration.");
+                _messageBoxService.ShowError("Error: Invalid building configuration.",
+                   Localization.Localization.Translations["Error"]);
             }
         }
 

--- a/AnnoDesigner/ViewModels/PreferencesViewModel.cs
+++ b/AnnoDesigner/ViewModels/PreferencesViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Navigation;
 using AnnoDesigner.Core.Models;
+using AnnoDesigner.Core.Services;
 using AnnoDesigner.Models;
 using AnnoDesigner.PreferencesPages;
 
@@ -11,7 +12,11 @@ namespace AnnoDesigner.ViewModels
 {
     public class PreferencesViewModel : Notify
     {
-        public PreferencesViewModel(IAppSettings appSettings, ICommons commons, HotkeyCommandManager manager, NavigationService navigationService)
+        public PreferencesViewModel(IAppSettings appSettings,
+            ICommons commons,
+            HotkeyCommandManager manager,
+            NavigationService navigationService,
+            IMessageBoxService messageBoxServiceToUse)
         {
             this.appSettings = appSettings;
             this.navigationService = navigationService;
@@ -19,7 +24,7 @@ namespace AnnoDesigner.ViewModels
 
             ViewModels = new Dictionary<string, object>()
             {
-                { nameof(ManageKeybindingsPage),  new ManageKeybindingsViewModel(manager, commons) },
+                { nameof(ManageKeybindingsPage),  new ManageKeybindingsViewModel(manager, commons, messageBoxServiceToUse) },
                 { nameof(UpdateSettingsPage), "" }
             };
         }

--- a/Tests/AnnoDesigner.Tests/BuildingSettingsViewModelTests.cs
+++ b/Tests/AnnoDesigner.Tests/BuildingSettingsViewModelTests.cs
@@ -8,12 +8,14 @@ using AnnoDesigner.Core.Models;
 using AnnoDesigner.Core.Presets.Models;
 using Moq;
 using System.Collections.ObjectModel;
+using AnnoDesigner.Core.Services;
 
 namespace AnnoDesigner.Tests
 {
     public class BuildingSettingsViewModelTests
     {
         private readonly IAppSettings _mockedAppSettings;
+        private readonly IMessageBoxService _mockedMessageBoxService;
 
         public BuildingSettingsViewModelTests()
         {
@@ -22,11 +24,13 @@ namespace AnnoDesigner.Tests
             Localization.Localization.Init(commonsMock.Object);
 
             _mockedAppSettings = new Mock<IAppSettings>().Object;
+            _mockedMessageBoxService = new Mock<IMessageBoxService>().Object;
         }
 
         private BuildingSettingsViewModel GetViewModel(IAppSettings appSettingsToUse = null)
         {
-            return new BuildingSettingsViewModel(appSettingsToUse ?? _mockedAppSettings);
+            return new BuildingSettingsViewModel(appSettingsToUse ?? _mockedAppSettings,
+                _mockedMessageBoxService);
         }
 
         #region ctor tests

--- a/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
+++ b/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
@@ -15,6 +15,7 @@ using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.RecentFiles;
 using System.IO.Abstractions.TestingHelpers;
 using AnnoDesigner.Core.Services;
+using AnnoDesigner.Core.Presets.Models;
 
 namespace AnnoDesigner.Tests
 {
@@ -460,7 +461,7 @@ namespace AnnoDesigner.Tests
             appSettings.Verify(x => x.Save(), Times.Once);
         }
 
-        [Theory(Skip = "needs abstraction of 'MessageBox.Show' in BuildingSettingsViewModel")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public void SaveSettings_IsCalled_ShouldSaveIsPavedStreet(bool expectedIsPavedStreet)
@@ -469,7 +470,15 @@ namespace AnnoDesigner.Tests
             var appSettings = new Mock<IAppSettings>();
             appSettings.SetupAllProperties();
 
-            var viewModel = GetViewModel(null, appSettings.Object);
+            var presets = new BuildingPresets
+            {
+                Buildings = new List<BuildingInfo>()
+            };
+
+            var canvas = new Mock<IAnnoCanvas>();
+            canvas.SetupGet(x => x.BuildingPresets).Returns(() => presets);
+
+            var viewModel = GetViewModel(null, appSettings.Object, annoCanvasToUse: canvas.Object);
             viewModel.BuildingSettingsViewModel.IsPavedStreet = expectedIsPavedStreet;
 
             // Act

--- a/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
+++ b/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
@@ -14,6 +14,7 @@ using System.Windows.Input;
 using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.RecentFiles;
 using System.IO.Abstractions.TestingHelpers;
+using AnnoDesigner.Core.Services;
 
 namespace AnnoDesigner.Tests
 {
@@ -23,6 +24,7 @@ namespace AnnoDesigner.Tests
         private readonly IAppSettings _mockedAppSettings;
         private readonly IAnnoCanvas _mockedAnnoCanvas;
         private readonly IRecentFilesHelper _inMemoryRecentFilesHelper;
+        private readonly IMessageBoxService _mockedMessageBoxService;
 
         public MainViewModelTests()
         {
@@ -38,16 +40,20 @@ namespace AnnoDesigner.Tests
             _mockedAnnoCanvas = annoCanvasMock.Object;
 
             _inMemoryRecentFilesHelper = new RecentFilesHelper(new RecentFilesInMemorySerializer(), new MockFileSystem());
+
+            _mockedMessageBoxService = new Mock<IMessageBoxService>().Object;
         }
 
         private MainViewModel GetViewModel(ICommons commonsToUse = null,
             IAppSettings appSettingsToUse = null,
             IRecentFilesHelper recentFilesHelperToUse = null,
+            IMessageBoxService messageBoxServiceToUse = null,
             IAnnoCanvas annoCanvasToUse = null)
         {
             return new MainViewModel(commonsToUse ?? _mockedCommons,
                 appSettingsToUse ?? _mockedAppSettings,
-                recentFilesHelperToUse ?? _inMemoryRecentFilesHelper)
+                recentFilesHelperToUse ?? _inMemoryRecentFilesHelper,
+                messageBoxServiceToUse ?? _mockedMessageBoxService)
             {
                 AnnoCanvas = annoCanvasToUse ?? _mockedAnnoCanvas
             };


### PR DESCRIPTION
This PR adds a service which abstracts the use of `MessageBox`es.
It is considered as a first step to localize `MessageBox`es (#71).