### PR TITLE
Add support for loading colors (grid lines; object border lines) from settings

### DIFF
--- a/AnnoDesigner.Core/Helper/SerializationHelper.cs
+++ b/AnnoDesigner.Core/Helper/SerializationHelper.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using AnnoDesigner.Core.Models;
 using Newtonsoft.Json;
 
 namespace AnnoDesigner.Core.Helper
@@ -16,7 +13,7 @@ namespace AnnoDesigner.Core.Helper
         /// <typeparam name="T">type of the object being serialized</typeparam>
         /// <param name="obj">object to serialize</param>
         /// <param name="filename">output JSON filename</param>
-        public static void SaveToFile<T>(T obj, string filename) where T : class
+        public static void SaveToFile<T>(T obj, string filename)
         {
             File.WriteAllText(filename, SaveToJsonString(obj));
         }
@@ -27,7 +24,7 @@ namespace AnnoDesigner.Core.Helper
         /// <typeparam name="T">type of the object being serialized</typeparam>
         /// <param name="obj">object to serialize</param>
         /// <param name="stream">output JSON stream</param>
-        public static void SaveToStream<T>(T obj, Stream stream) where T : class
+        public static void SaveToStream<T>(T obj, Stream stream)
         {
             var serializer = new JsonSerializer();
             using var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true);//use constructor that does not close base stream
@@ -42,7 +39,7 @@ namespace AnnoDesigner.Core.Helper
         /// </summary>
         /// <typeparam name="T">type of the object being serialized</typeparam>
         /// <param name="obj">object to serialize</param>
-        public static string SaveToJsonString<T>(T obj, Formatting formatting = Formatting.None) where T : class
+        public static string SaveToJsonString<T>(T obj, Formatting formatting = Formatting.None)
         {
             return JsonConvert.SerializeObject(obj, formatting);
         }
@@ -53,7 +50,7 @@ namespace AnnoDesigner.Core.Helper
         /// <typeparam name="T">type of object being deserialized</typeparam>
         /// <param name="filename">input JSON filename</param>
         /// <returns>deserialized object</returns>
-        public static T LoadFromFile<T>(string filename) where T : class
+        public static T LoadFromFile<T>(string filename)
         {
             var fileContents = File.ReadAllText(filename);
             return LoadFromJsonString<T>(fileContents);
@@ -65,7 +62,7 @@ namespace AnnoDesigner.Core.Helper
         /// <typeparam name="T">type of object being deserialized</typeparam>
         /// <param name="stream">input JSON stream</param>
         /// <returns>deserialized object</returns>
-        public static T LoadFromStream<T>(Stream stream) where T : class
+        public static T LoadFromStream<T>(Stream stream)
         {
             var serializer = new JsonSerializer();
             using var sr = new StreamReader(stream);
@@ -83,7 +80,7 @@ namespace AnnoDesigner.Core.Helper
         /// <exception cref="Newtonsoft.Json.JsonSerializationException">If <paramref name="jsonString"/> 
         /// is null or empty, or the json is not valid for the given object.</exception>
         /// <returns>deserialized object</returns>
-        public static T LoadFromJsonString<T>(string jsonString) where T : class
+        public static T LoadFromJsonString<T>(string jsonString)
         {
             if (string.IsNullOrWhiteSpace(jsonString))
             {
@@ -98,7 +95,7 @@ namespace AnnoDesigner.Core.Helper
         /// <typeparam name="T">type of object being deserialized</typeparam>
         /// <param name="s">JSON string to deserialize</param>
         /// <returns>deserialized object</returns>
-        public static T LoadFromJsonStringLegacy<T>(string jsonString) where T : class
+        public static T LoadFromJsonStringLegacy<T>(string jsonString)
         {
             using var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonString));
             var serializer = new DataContractJsonSerializer(typeof(T));

--- a/AnnoDesigner.Core/Models/IAppSettings.cs
+++ b/AnnoDesigner.Core/Models/IAppSettings.cs
@@ -41,5 +41,7 @@ namespace AnnoDesigner.Core.Models
         bool UpdateSupportsPrerelease { get; set; }
         string HotkeyMappings { get; set; }
         string RecentFiles { get; set; }
+        string ColorGridLines { get; set; }
+        string ColorObjectBorderLines { get; set; }
     }
 }

--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -498,6 +498,8 @@ namespace AnnoDesigner
         {
             var colorFromJson = SerializationHelper.LoadFromJsonString<SerializableColor>(_appSettings.ColorObjectBorderLines);//explicit variable to make debugging easier
             _linePen = _penCache.GetPen(_brushCache.GetSolidBrush(colorFromJson), DPI_FACTOR * 1);
+
+            InvalidateVisual();
         }
 
         private readonly Typeface TYPEFACE = new Typeface("Verdana");

--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using AnnoDesigner.Core;
 using AnnoDesigner.Core.Extensions;
+using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.Layout;
 using AnnoDesigner.Core.Layout.Exceptions;
 using AnnoDesigner.Core.Layout.Models;
@@ -49,6 +50,7 @@ namespace AnnoDesigner
         public event EventHandler<EventArgs> ColorsInLayoutUpdated;
 
         #region Properties
+
         /// <summary>
         /// Contains all loaded icons as a mapping of name (the filename without extension) to loaded BitmapImage.
         /// </summary>
@@ -334,8 +336,11 @@ namespace AnnoDesigner
 
         #region Privates and constructor
 
+        private const int DPI_FACTOR = 1;
+
         private readonly ILayoutLoader _layoutLoader;
         private readonly ICoordinateHelper _coordinateHelper;
+        private readonly IAppSettings _appSettings;
         private readonly IBrushCache _brushCache;
         private readonly IPenCache _penCache;
         private readonly IMessageBoxService _messageBoxService;
@@ -366,7 +371,6 @@ namespace AnnoDesigner
         /// <summary>
         /// Indicates the current mouse mode.
         /// </summary>
-        //private MouseMode CurrentMode
         private MouseMode CurrentMode
         {
             get
@@ -474,14 +478,41 @@ namespace AnnoDesigner
             RemoveSelectedObjects(new List<LayoutObject>() { objectToRemove }, includeSameObjects);
         }
 
+        /// <summary>
+        /// Used to load current color for grid lines from settings.
+        /// </summary>
+        /// <remarks>Also calls <see cref="UIElement.InvalidateVisual()"/></remarks>
+        public void LoadGridLineColor()
+        {
+            var colorFromJson = SerializationHelper.LoadFromJsonString<SerializableColor>(_appSettings.ColorGridLines);//explicit variable to make debugging easier
+            _gridLinePen = _penCache.GetPen(_brushCache.GetSolidBrush(colorFromJson), DPI_FACTOR * 1);
+
+            InvalidateVisual();
+        }
+
+        /// <summary>
+        /// Used to load current color for object border lines from settings.
+        /// </summary>
+        /// <remarks>Also calls <see cref="UIElement.InvalidateVisual()"/></remarks>
+        public void LoadObjectBorderLineColor()
+        {
+            var colorFromJson = SerializationHelper.LoadFromJsonString<SerializableColor>(_appSettings.ColorObjectBorderLines);//explicit variable to make debugging easier
+            _linePen = _penCache.GetPen(_brushCache.GetSolidBrush(colorFromJson), DPI_FACTOR * 1);
+        }
+
         private readonly Typeface TYPEFACE = new Typeface("Verdana");
 
         #region Pens and Brushes
 
         /// <summary>
-        /// Used for grid lines and object borders.
+        /// Used for object borders.
         /// </summary>
-        private readonly Pen _linePen;
+        private Pen _linePen;
+
+        /// <summary>
+        /// Used for grid lines.
+        /// </summary>
+        private Pen _gridLinePen;
 
         public double LinePenThickness
         {
@@ -524,6 +555,7 @@ namespace AnnoDesigner
 
         public AnnoCanvas(BuildingPresets presetsToUse,
             Dictionary<string, IconImage> iconsToUse,
+            IAppSettings appSettingsToUse = null,
             ICoordinateHelper coordinateHelperToUse = null,
             IBrushCache brushCacheToUse = null,
             IPenCache penCacheToUse = null,
@@ -531,7 +563,7 @@ namespace AnnoDesigner
         {
             InitializeComponent();
 
-
+            _appSettings = appSettingsToUse ?? new AppSettings();
             _coordinateHelper = coordinateHelperToUse ?? new CoordinateHelper();
             _brushCache = brushCacheToUse ?? new BrushCache();
             _penCache = penCacheToUse ?? new PenCache();
@@ -553,6 +585,7 @@ namespace AnnoDesigner
             copyCommand = new RelayCommand(ExecuteCopy);
             pasteCommand = new RelayCommand(ExecutePaste);
             deleteCommand = new RelayCommand(ExecuteDelete);
+
             //Set up default keybindings
             var rotateBinding = new KeyBinding()
             {
@@ -594,13 +627,14 @@ namespace AnnoDesigner
             //InputBindings.Add(rotateBinding);
             //InputBindings.Add(copyBinding);
             //InputBindings.Add(pasteBinding);
-            //InputBindings.Add(deleteBinding);
+            //InputBindings.Add(deleteBinding);            
 
-            const int dpiFactor = 1;
-            _linePen = _penCache.GetPen(Brushes.Black, dpiFactor * 1);
-            _highlightPen = _penCache.GetPen(Brushes.Yellow, dpiFactor * 2);
-            _radiusPen = _penCache.GetPen(Brushes.Black, dpiFactor * 2);
-            _influencedPen = _penCache.GetPen(Brushes.LawnGreen, dpiFactor * 2);
+            LoadGridLineColor();
+            LoadObjectBorderLineColor();
+
+            _highlightPen = _penCache.GetPen(Brushes.Yellow, DPI_FACTOR * 2);
+            _radiusPen = _penCache.GetPen(Brushes.Black, DPI_FACTOR * 2);
+            _influencedPen = _penCache.GetPen(Brushes.LawnGreen, DPI_FACTOR * 2);
 
             var color = Colors.LightYellow;
             color.A = 32;
@@ -680,6 +714,7 @@ namespace AnnoDesigner
         #endregion
 
         #region Rendering
+
         /// <summary>
         /// Renders the whole scene including grid, placed objects, current object, selection highlights, influence radii and selection rectangle.
         /// </summary>
@@ -693,7 +728,7 @@ namespace AnnoDesigner
             //var dpiFactor = 1 / m.M11;
 
             // assure pixel perfect drawing
-            var halfPenWidth = _linePen.Thickness / 2;
+            var halfPenWidth = _gridLinePen.Thickness / 2;
             var guidelines = new GuidelineSet();
             guidelines.GuidelinesX.Add(halfPenWidth);
             guidelines.GuidelinesY.Add(halfPenWidth);
@@ -711,11 +746,11 @@ namespace AnnoDesigner
             {
                 for (var i = 0; i < width; i += _gridStep)
                 {
-                    drawingContext.DrawLine(_linePen, new Point(i, 0), new Point(i, height));
+                    drawingContext.DrawLine(_gridLinePen, new Point(i, 0), new Point(i, height));
                 }
                 for (var i = 0; i < height; i += _gridStep)
                 {
-                    drawingContext.DrawLine(_linePen, new Point(0, i), new Point(width, i));
+                    drawingContext.DrawLine(_gridLinePen, new Point(0, i), new Point(width, i));
                 }
             }
 

--- a/AnnoDesigner/Models/AppSettings.cs
+++ b/AnnoDesigner/Models/AppSettings.cs
@@ -192,8 +192,20 @@ namespace AnnoDesigner.Models
 
         public string RecentFiles
         {
-            get { return Settings.Default.RecentFiles; }
-            set { Settings.Default.RecentFiles = value; }
+            get => Settings.Default.RecentFiles;
+            set => Settings.Default.RecentFiles = value;
+        }
+
+        public string ColorGridLines
+        {
+            get => Settings.Default.ColorGridLines;
+            set => Settings.Default.ColorGridLines = value;
+        }
+
+        public string ColorObjectBorderLines
+        {
+            get => Settings.Default.ColorObjectBorderLines;
+            set => Settings.Default.ColorObjectBorderLines = value;
         }
     }
 }

--- a/AnnoDesigner/Properties/Settings.Designer.cs
+++ b/AnnoDesigner/Properties/Settings.Designer.cs
@@ -403,5 +403,29 @@ namespace AnnoDesigner.Properties {
                 this["RecentFiles"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("{\"A\":255,\"R\":0,\"G\":0,\"B\":0}")]
+        public string ColorGridLines {
+            get {
+                return ((string)(this["ColorGridLines"]));
+            }
+            set {
+                this["ColorGridLines"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("{\"A\":255,\"R\":0,\"G\":0,\"B\":0}")]
+        public string ColorObjectBorderLines {
+            get {
+                return ((string)(this["ColorObjectBorderLines"]));
+            }
+            set {
+                this["ColorObjectBorderLines"] = value;
+            }
+        }
     }
 }

--- a/AnnoDesigner/Properties/Settings.settings
+++ b/AnnoDesigner/Properties/Settings.settings
@@ -93,10 +93,16 @@
       <Value Profile="(Default)">8.7</Value>
     </Setting>
     <Setting Name="HotkeyMappings" Type="System.String" Scope="User">
-    <Value Profile="(Default)" />
+      <Value Profile="(Default)" />
     </Setting>
     <Setting Name="RecentFiles" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="ColorGridLines" Type="System.String" Scope="User">
+      <Value Profile="(Default)">{"A":255,"R":0,"G":0,"B":0}</Value>
+    </Setting>
+    <Setting Name="ColorObjectBorderLines" Type="System.String" Scope="User">
+      <Value Profile="(Default)">{"A":255,"R":0,"G":0,"B":0}</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -1083,7 +1083,7 @@ namespace AnnoDesigner.ViewModels
                 }
 
                 // initialize output canvas
-                var target = new AnnoCanvas(AnnoCanvas.BuildingPresets, icons, _coordinateHelper, _brushCache, _penCache, _messageBoxService)
+                var target = new AnnoCanvas(AnnoCanvas.BuildingPresets, icons, _appSettings, _coordinateHelper, _brushCache, _penCache, _messageBoxService)
                 {
                     PlacedObjects = allObjects,
                     RenderGrid = AnnoCanvas.RenderGrid,

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -108,6 +108,12 @@
             <setting name="RecentFiles" serializeAs="String">
                 <value />
             </setting>
+            <setting name="ColorGridLines" serializeAs="String">
+                <value>{"A":255,"R":0,"G":0,"B":0}</value>
+            </setting>
+            <setting name="ColorObjectBorderLines" serializeAs="String">
+                <value>{"A":255,"R":0,"G":0,"B":0}</value>
+            </setting>
         </AnnoDesigner.Properties.Settings>
     </userSettings>
     <applicationSettings>


### PR DESCRIPTION
This PR adds the functionality to load the colors for grid lines and object borders from the settings.
It is a step towards fixing the issue #211.
A UI for changing the color will be added with PR #238.