### PR TITLE
Add WPFToolkit to Licenses window (fix #236)

### DIFF
--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -78,7 +78,7 @@
     <ProjectReference Include="..\AnnoDesigner.Core\AnnoDesigner.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.8.1" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.8.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
     <PackageReference Include="NLog" Version="4.7.2" />

--- a/AnnoDesigner/LicensesWindow.xaml
+++ b/AnnoDesigner/LicensesWindow.xaml
@@ -11,7 +11,7 @@
         xmlns:b="http://schemas.microsoft.com/xaml/behaviors" x:Class="AnnoDesigner.LicensesWindow"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance IsDesignTimeCreatable=True, Type={x:Type viewModels:LicensesViewModel}}"
-        Title="{l:Localize Licenses}" Height="450" Width="500"
+        Title="{l:Localize Licenses}" Height="450" Width="600"
         IsTabStop="False">
     <Window.Resources>
         <coreConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed" />
@@ -44,7 +44,7 @@
                                         </Hyperlink>
                                     </TextBlock>
                                 </Grid>
-                                <ToggleButton x:Name="ShowAssets" Grid.Column="1" Grid.Row="1" Grid.RowSpan="2" Template="{DynamicResource ToggleButtonTemplate}">
+                                <ToggleButton x:Name="ShowAssets" Grid.Column="1" Grid.Row="1" Grid.RowSpan="2" Template="{DynamicResource ToggleButtonTemplate}" Visibility="{Binding HasAssets, Converter={StaticResource BoolToVisibilityConverter}}">
                                     <ToggleButton.Resources>
                                         <ControlTemplate x:Key="ToggleButtonTemplate" TargetType="{x:Type ToggleButton}">
                                             <Grid>

--- a/AnnoDesigner/Models/LicenseInfo.cs
+++ b/AnnoDesigner/Models/LicenseInfo.cs
@@ -13,5 +13,6 @@ namespace AnnoDesigner.Models
         public string LicenseURL { get; set; }
         public string ProjectWebsite { get; set; }
         public IEnumerable<string> Assets { get; set; }
+        public bool HasAssets => Assets != null && Assets.Count() > 0;
     }
 }

--- a/AnnoDesigner/ViewModels/LicensesViewModel.cs
+++ b/AnnoDesigner/ViewModels/LicensesViewModel.cs
@@ -19,6 +19,7 @@ namespace AnnoDesigner.ViewModels
         }
 
         private const string APACHE_2 = "Apache-2.0 License";
+        private const string MS_PL = "Microsoft Public License (Ms-PL)";
         //private const string MIT = "MIT License";
         //etc
 
@@ -26,7 +27,7 @@ namespace AnnoDesigner.ViewModels
         {
             Licenses = new ObservableCollection<LicenseInfo>
             {
-                new LicenseInfo()
+                new LicenseInfo
                 {
                     License = APACHE_2,
                     LicenseURL = "https://github.com/google/material-design-icons/blob/master/LICENSE",
@@ -39,10 +40,15 @@ namespace AnnoDesigner.ViewModels
                         "right-click.png",
                         "chevron-up.png"
                     }
+                },
+                new LicenseInfo
+                {
+                    License=MS_PL,
+                    LicenseURL="https://licenses.nuget.org/MS-PL",
+                    ProjectName="Extended WPF Toolkit™ (3.8.2)",
+                    ProjectWebsite="https://github.com/xceedsoftware/wpftoolkit"
                 }
             };
-
-
 
 
 


### PR DESCRIPTION
This PR fixes #236.
Also the Toolkit was updated to latest usable version (3.8.2) to comply with the license.
The Toggle to show assets is only shown if there are assets present.