### PR TITLE
Remove `IUpdateHelper` from `ICommons`

### DIFF
--- a/AnnoDesigner/App.xaml.cs
+++ b/AnnoDesigner/App.xaml.cs
@@ -28,12 +28,14 @@ namespace AnnoDesigner
         private static readonly IAppSettings _appSettings;
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
         private static readonly IMessageBoxService _messageBoxService;
+        private static readonly IUpdateHelper _updateHelper;
 
         static App()
         {
             _commons = Commons.Instance;
             _appSettings = AppSettings.Instance;
             _messageBoxService = new MessageBoxService();
+            _updateHelper = new UpdateHelper(ApplicationPath, _appSettings, _messageBoxService);
         }
 
         public App()
@@ -179,14 +181,14 @@ namespace AnnoDesigner
                 }
 
                 //var updateWindow = new UpdateWindow();                
-                await _commons.UpdateHelper.ReplaceUpdatedPresetsFilesAsync();
+                await _updateHelper.ReplaceUpdatedPresetsFilesAsync();
 
                 Localization.Localization.Init(_commons);
 
                 var serializer = new RecentFilesAppSettingsSerializer(_appSettings);
 
                 IRecentFilesHelper recentFilesHelper = new RecentFilesHelper(serializer, new FileSystem());
-                var mainVM = new MainViewModel(_commons, _appSettings, recentFilesHelper, _messageBoxService);
+                var mainVM = new MainViewModel(_commons, _appSettings, recentFilesHelper, _messageBoxService, _updateHelper);
 
                 //TODO MainWindow.ctor calls AnnoCanvas.ctor loads presets -> change logic when to load data 
                 MainWindow = new MainWindow(_appSettings);

--- a/AnnoDesigner/Commons.cs
+++ b/AnnoDesigner/Commons.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.IO;
 using AnnoDesigner.Models;
-using AnnoDesigner.Services;
 using NLog;
 
 namespace AnnoDesigner
@@ -10,7 +9,6 @@ namespace AnnoDesigner
     public class Commons : ICommons
     {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
-        private static readonly IUpdateHelper _updateHelper;
         private static string _selectedLanguage;
 
         public event EventHandler SelectedLanguageChanged;
@@ -22,23 +20,13 @@ namespace AnnoDesigner
         public static Commons Instance
         {
             get { return lazy.Value; }
-        }
-
-        static Commons()
-        {
-            _updateHelper = new UpdateHelper(App.ApplicationPath, AppSettings.Instance, new MessageBoxService());
-        }
+        }        
 
         private Commons()
         {
         }
 
         #endregion
-
-        public IUpdateHelper UpdateHelper
-        {
-            get { return _updateHelper; }
-        }
 
         public string SelectedLanguage
         {

--- a/AnnoDesigner/Models/ICommons.cs
+++ b/AnnoDesigner/Models/ICommons.cs
@@ -10,8 +10,6 @@ namespace AnnoDesigner.Models
     {
         event EventHandler SelectedLanguageChanged;
 
-        IUpdateHelper UpdateHelper { get; }
-
         string SelectedLanguage { get; set; }
 
         bool CanWriteInFolder(string folderPathToCheck = null);

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -43,6 +43,7 @@ namespace AnnoDesigner.ViewModels
         private readonly IPenCache _penCache;
         private readonly IRecentFilesHelper _recentFilesHelper;
         private readonly IMessageBoxService _messageBoxService;
+        private readonly IUpdateHelper _updateHelper;
 
         public event EventHandler<EventArgs> ShowStatisticsChanged;
 
@@ -80,6 +81,7 @@ namespace AnnoDesigner.ViewModels
             IAppSettings appSettingsToUse,
             IRecentFilesHelper recentFilesHelperToUse,
             IMessageBoxService messageBoxServiceToUse,
+            IUpdateHelper updateHelperToUse,
             ILayoutLoader layoutLoaderToUse = null,
             ICoordinateHelper coordinateHelperToUse = null,
             IBrushCache brushCacheToUse = null,
@@ -91,6 +93,7 @@ namespace AnnoDesigner.ViewModels
             _appSettings = appSettingsToUse;
             _recentFilesHelper = recentFilesHelperToUse;
             _messageBoxService = messageBoxServiceToUse;
+            _updateHelper = updateHelperToUse;
 
             _layoutLoader = layoutLoaderToUse ?? new LayoutLoader();
             _coordinateHelper = coordinateHelperToUse ?? new CoordinateHelper();
@@ -115,7 +118,7 @@ namespace AnnoDesigner.ViewModels
 
             AboutViewModel = new AboutViewModel();
 
-            PreferencesUpdateViewModel = new UpdateSettingsViewModel(_commons, _appSettings);
+            PreferencesUpdateViewModel = new UpdateSettingsViewModel(_commons, _appSettings, _updateHelper);
             PreferencesKeyBindingsViewModel = new ManageKeybindingsViewModel(HotkeyCommandManager, _commons, _messageBoxService);
             PreferencesGeneralViewModel = new GeneralSettingsViewModel(_appSettings, _commons);
 

--- a/AnnoDesigner/ViewModels/UpdateSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/UpdateSettingsViewModel.cs
@@ -21,6 +21,7 @@ namespace AnnoDesigner.ViewModels
 
         private readonly ICommons _commons;
         private readonly IAppSettings _appSettings;
+        private readonly IUpdateHelper _updateHelper;
 
         private bool _automaticUpdateCheck;
         private bool _updateSupportsPrerelease;
@@ -35,10 +36,12 @@ namespace AnnoDesigner.ViewModels
         private string _busyContent;
 
         public UpdateSettingsViewModel(ICommons commonsToUse,
-            IAppSettings appSettingsToUse)
+            IAppSettings appSettingsToUse,
+            IUpdateHelper updateHelperToUse)
         {
             _commons = commonsToUse;
             _appSettings = appSettingsToUse;
+            _updateHelper = updateHelperToUse;
 
             CheckForUpdatesCommand = new RelayCommand(ExecuteCheckForUpdates);
             OpenReleasesCommand = new RelayCommand(ExecuteOpenReleases);
@@ -137,7 +140,7 @@ namespace AnnoDesigner.ViewModels
         {
             FoundPresetRelease = null;
 
-            var foundRelease = await _commons.UpdateHelper.GetAvailableReleasesAsync(ReleaseType.Presets);
+            var foundRelease = await _updateHelper.GetAvailableReleasesAsync(ReleaseType.Presets);
             if (foundRelease == null)
             {
                 return;
@@ -217,7 +220,7 @@ namespace AnnoDesigner.ViewModels
             }
 
             //Context is required here, do not use ConfigureAwait(false)
-            var newLocation = await _commons.UpdateHelper.DownloadReleaseAsync(FoundPresetRelease);
+            var newLocation = await _updateHelper.DownloadReleaseAsync(FoundPresetRelease);
             logger.Debug($"downloaded new preset ({FoundPresetRelease.Version}): {newLocation}");
 
             IsBusy = false;

--- a/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
+++ b/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
@@ -23,6 +23,7 @@ namespace AnnoDesigner.Tests
         private readonly IAnnoCanvas _mockedAnnoCanvas;
         private readonly IRecentFilesHelper _inMemoryRecentFilesHelper;
         private readonly IMessageBoxService _mockedMessageBoxService;
+        private readonly IUpdateHelper _mockedUpdateHelper;
 
         public MainViewModelTests()
         {
@@ -40,18 +41,21 @@ namespace AnnoDesigner.Tests
             _inMemoryRecentFilesHelper = new RecentFilesHelper(new RecentFilesInMemorySerializer(), new MockFileSystem());
 
             _mockedMessageBoxService = new Mock<IMessageBoxService>().Object;
+            _mockedUpdateHelper = new Mock<IUpdateHelper>().Object;
         }
 
         private MainViewModel GetViewModel(ICommons commonsToUse = null,
             IAppSettings appSettingsToUse = null,
             IRecentFilesHelper recentFilesHelperToUse = null,
             IMessageBoxService messageBoxServiceToUse = null,
+            IUpdateHelper updateHelperToUse = null,
             IAnnoCanvas annoCanvasToUse = null)
         {
             return new MainViewModel(commonsToUse ?? _mockedCommons,
                 appSettingsToUse ?? _mockedAppSettings,
                 recentFilesHelperToUse ?? _inMemoryRecentFilesHelper,
-                messageBoxServiceToUse ?? _mockedMessageBoxService)
+                messageBoxServiceToUse ?? _mockedMessageBoxService,
+                updateHelperToUse ?? _mockedUpdateHelper)
             {
                 AnnoCanvas = annoCanvasToUse ?? _mockedAnnoCanvas
             };


### PR DESCRIPTION
This PR moves the `IUpdateHelper` out of `ICommons`.
The primary case is to help PR #243, but I wanted to make it a separate change/PR.