### PR TITLE
Fix #257: Add "Default" button to zoom sensitivity

### DIFF
--- a/AnnoDesigner/Constants.cs
+++ b/AnnoDesigner/Constants.cs
@@ -50,6 +50,11 @@ namespace AnnoDesigner
         public const double ZoomSensitivitySliderMaximum = 100d;
 
         /// <summary>
+        /// The default zoom sensitivity value.
+        /// </summary>
+        public const double ZoomSensitivityPercentageDefault = 50d;
+
+        /// <summary>
         /// The value that affects the rendering sizes of icons on the anno canvas. 1 produces an icon of the biggest size.
         /// </summary>
         public const double IconSizeFactor = 1.1;

--- a/AnnoDesigner/Localization/Localization.cs
+++ b/AnnoDesigner/Localization/Localization.cs
@@ -211,6 +211,7 @@ namespace AnnoDesigner.Localization
                         { "ColorTypeCustom" , "Custom" },
                         { "Warning" , "Warning" },
                         { "FileNotFound" , "The file was not found." },
+                        { "Default" , "Default" },
                     }
                 },
                 {
@@ -370,6 +371,7 @@ namespace AnnoDesigner.Localization
                         { "ColorTypeCustom" , "Benutzerdefiniert" },
                         { "Warning" , "Warnung" },
                         { "FileNotFound" , "Die Datei wurde nicht gefunden." },
+                        { "Default" , "Standard" },
                     }
                 },
                 {
@@ -529,6 +531,7 @@ namespace AnnoDesigner.Localization
                         { "ColorTypeCustom" , "Personnalisation" },
                         { "Warning" , "Avertissement" },
                         { "FileNotFound" , "Le fichier n'a pas été retrouvé." },
+                        { "Default" , "Défaut" },
                     }
                 },
                 {
@@ -688,6 +691,7 @@ namespace AnnoDesigner.Localization
                         { "ColorTypeCustom" , "Niestandardowy" },
                         { "Warning" , "Ostrzeżenie" },
                         { "FileNotFound" , "Plik nie został znaleziony." },
+                        { "Default" , "Domyślnie" },
                     }
                 },
                 {
@@ -847,6 +851,7 @@ namespace AnnoDesigner.Localization
                         { "ColorTypeCustom" , "Пользовательский" },
                         { "Warning" , "Предупреждение" },
                         { "FileNotFound" , "Файл не был найден." },
+                        { "Default" , "По умолчанию" },
                     }
                 },
             };

--- a/AnnoDesigner/PreferencesPages/GeneralSettingsPage.xaml
+++ b/AnnoDesigner/PreferencesPages/GeneralSettingsPage.xaml
@@ -128,6 +128,7 @@
                                   SharedSizeGroup="PreferenceLabel" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
             <TextBlock Grid.Column="0"
@@ -140,10 +141,15 @@
                     Width="150"
                     TickFrequency="1"
                     IsSnapToTickEnabled="True"
-                    TickPlacement="None"/>
+                    TickPlacement="None" />
             <TextBlock Grid.Column="2"
                        Margin="5,0,0,0"
                        Text="{Binding ElementName=ZoomSlider, Path=Value, StringFormat='{}{0}%'}" />
+            <Button Grid.Column="3"
+                    Content="{l:Localize Default}"
+                    Command="{Binding ResetZoomSensitivityCommand}"
+                    Padding="5,2"
+                    Margin="20,0,0,0" />
         </Grid>
 
         <StackPanel Margin="20,0,0,10">

--- a/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows.Input;
 using System.Windows.Media;
 using AnnoDesigner.Core.Helper;
 using AnnoDesigner.Core.Models;
@@ -36,6 +37,8 @@ namespace AnnoDesigner.ViewModels
 
             UseZoomToPoint = _appSettings.UseZoomToPoint;
             ZoomSensitivityPercentage = _appSettings.ZoomSensitivityPercentage;
+
+            ResetZoomSensitivityCommand = new RelayCommand(ExecuteResetZoomSensitivity, CanExecuteResetZoomSensitivity);
 
             GridLineColors = new ObservableCollection<UserDefinedColor>();
             RefreshGridLineColors();
@@ -314,6 +317,18 @@ namespace AnnoDesigner.ViewModels
                     _appSettings.Save();
                 }
             }
+        }
+
+        public ICommand ResetZoomSensitivityCommand { get; private set; }
+
+        private void ExecuteResetZoomSensitivity(object param)
+        {
+            ZoomSensitivityPercentage = Constants.ZoomSensitivityPercentageDefault;
+        }
+
+        private bool CanExecuteResetZoomSensitivity(object param)
+        {
+            return ZoomSensitivityPercentage != Constants.ZoomSensitivityPercentageDefault;
         }
     }
 }


### PR DESCRIPTION
This PR fixes #257 and adds a "Default" button to restore the zoom sensitivity to the default value (50).