### PR TITLE
Opt in to per-monitor DPI awareness

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,7 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
 # Suggest more modern language features when available
-dotnet_style_object_initializer = true:suggestion
+dotnet_style_object_initializer = true:none
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion

--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>

--- a/AnnoDesigner/App.xaml.cs
+++ b/AnnoDesigner/App.xaml.cs
@@ -208,6 +208,7 @@ namespace AnnoDesigner
             IRecentFilesHelper recentFilesHelper = new RecentFilesHelper(recentFilesSerializer, _fileSystem);
             var mainVM = new MainViewModel(_commons, _appSettings, recentFilesHelper, _messageBoxService, _updateHelper, _localizationHelper, _fileSystem);
 
+            //TODO MainWindow.ctor calls AnnoCanvas.ctor loads presets -> change logic when to load data 
             MainWindow = new MainWindow(_appSettings);
             MainWindow.DataContext = mainVM;
 

--- a/AnnoDesigner/App.xaml.cs
+++ b/AnnoDesigner/App.xaml.cs
@@ -88,15 +88,30 @@ namespace AnnoDesigner
             Environment.Exit(-1);
         }
 
+        private static string _executablePath;
         public static string ExecutablePath
         {
-            get { return Assembly.GetEntryAssembly().Location; }
-
+            get
+            {
+                if (_executablePath is null)
+                {
+                    _executablePath = Assembly.GetEntryAssembly().Location;
+                }
+                return _executablePath;
+            }
         }
 
+        private static string _applicationPath;
         public static string ApplicationPath
         {
-            get { return Path.GetDirectoryName(Assembly.GetEntryAssembly().Location); }
+            get 
+            {
+                if (_applicationPath is null)
+                {
+                    _applicationPath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                }
+                return _applicationPath;
+            }
         }
 
         public static string FilenameArgument { get; private set; }
@@ -117,107 +132,98 @@ namespace AnnoDesigner
                 }
             }
 
-            using (var mutexAnnoDesigner = new Mutex(true, MutexHelper.MUTEX_ANNO_DESIGNER, out bool createdNewMutex))
+            using var mutexAnnoDesigner = new Mutex(true, MutexHelper.MUTEX_ANNO_DESIGNER, out var createdNewMutex);
+            //Are there other processes still running?
+            if (!createdNewMutex)
             {
-                //Are there other processes still running?
-                if (!createdNewMutex)
-                {
-                    try
-                    {
-                        var currentTry = 0;
-                        const int maxTrys = 10;
-                        while (!createdNewMutex && currentTry < maxTrys)
-                        {
-                            logger.Trace($"Waiting for other processes to finish. Try {currentTry} of {maxTrys}");
-
-                            createdNewMutex = mutexAnnoDesigner.WaitOne(TimeSpan.FromSeconds(1), true);
-                            currentTry++;
-                        }
-
-                        if (!createdNewMutex)
-                        {
-                            _messageBoxService.ShowMessage("Another instance of the app is already running.");
-                            Environment.Exit(-1);
-                        }
-                    }
-                    catch (AbandonedMutexException)
-                    {
-                        //mutex was killed
-                        createdNewMutex = true;
-                    }
-                }
-
                 try
                 {
-                    //check if file is not corrupt
-                    _appSettings.Reload();
-
-                    if (_appSettings.SettingsUpgradeNeeded)
+                    var currentTry = 0;
+                    const int maxTrys = 10;
+                    while (!createdNewMutex && currentTry < maxTrys)
                     {
-                        _appSettings.Upgrade();
-                        _appSettings.SettingsUpgradeNeeded = false;
-                        _appSettings.Save();
+                        logger.Trace($"Waiting for other processes to finish. Try {currentTry} of {maxTrys}");
+
+                        createdNewMutex = mutexAnnoDesigner.WaitOne(TimeSpan.FromSeconds(1), true);
+                        currentTry++;
+                    }
+
+                    if (!createdNewMutex)
+                    {
+                        _messageBoxService.ShowMessage("Another instance of the app is already running.");
+                        Environment.Exit(-1);
                     }
                 }
-                catch (ConfigurationErrorsException ex)
+                catch (AbandonedMutexException)
                 {
-                    logger.Error(ex, "Error upgrading settings.");
-
-                    _messageBoxService.ShowError("The settings file has become corrupted. We must reset your settings.");
-
-                    var fileName = "";
-                    if (!string.IsNullOrEmpty(ex.Filename))
-                    {
-                        fileName = ex.Filename;
-                    }
-                    else
-                    {
-                        var innerException = ex.InnerException as ConfigurationErrorsException;
-                        if (innerException != null && !string.IsNullOrEmpty(innerException.Filename))
-                        {
-                            fileName = innerException.Filename;
-                        }
-                    }
-
-                    if (File.Exists(fileName))
-                    {
-                        File.Delete(fileName);
-                    }
-
-                    _appSettings.Reload();
+                    //mutex was killed
+                    createdNewMutex = true;
                 }
+            }
 
-                //var updateWindow = new UpdateWindow();                
-                await _updateHelper.ReplaceUpdatedPresetsFilesAsync();
+            try
+            {
+                //check if file is not corrupt
+                _appSettings.Reload();
 
-                var recentFilesSerializer = new RecentFilesAppSettingsSerializer(_appSettings);
-
-                IRecentFilesHelper recentFilesHelper = new RecentFilesHelper(recentFilesSerializer, _fileSystem);
-                var mainVM = new MainViewModel(_commons, _appSettings, recentFilesHelper, _messageBoxService, _updateHelper, _localizationHelper, _fileSystem);
-
-                //TODO MainWindow.ctor calls AnnoCanvas.ctor loads presets -> change logic when to load data 
-                MainWindow = new MainWindow(_appSettings);
-                MainWindow.DataContext = mainVM;
-                //MainWindow.Loaded += (s, args) => { updateWindow.Close(); };
-
-                //updateWindow.Show();
-
-                //If language is not recognized, bring up the language selection screen
-                if (!_commons.LanguageCodeMap.ContainsKey(_appSettings.SelectedLanguage))
+                if (_appSettings.SettingsUpgradeNeeded)
                 {
-                    var w = new Welcome();
-                    w.DataContext = mainVM.WelcomeViewModel;
-                    w.ShowDialog();
+                    _appSettings.Upgrade();
+                    _appSettings.SettingsUpgradeNeeded = false;
+                    _appSettings.Save();
+                }
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                logger.Error(ex, "Error upgrading settings.");
+
+                _messageBoxService.ShowError("The settings file has become corrupted. We must reset your settings.");
+
+                var fileName = "";
+                if (!string.IsNullOrEmpty(ex.Filename))
+                {
+                    fileName = ex.Filename;
                 }
                 else
                 {
-                    _commons.CurrentLanguage = _appSettings.SelectedLanguage;
+                    if (ex.InnerException is ConfigurationErrorsException innerException && !string.IsNullOrEmpty(innerException.Filename))
+                    {
+                        fileName = innerException.Filename;
+                    }
                 }
 
-                MainWindow.ShowDialog();
+                if (File.Exists(fileName))
+                {
+                    File.Delete(fileName);
+                }
 
-                //base.OnStartup(e);//needed?
+                _appSettings.Reload();
             }
+
+            //var updateWindow = new UpdateWindow();                
+            await _updateHelper.ReplaceUpdatedPresetsFilesAsync();
+
+            var recentFilesSerializer = new RecentFilesAppSettingsSerializer(_appSettings);
+
+            IRecentFilesHelper recentFilesHelper = new RecentFilesHelper(recentFilesSerializer, _fileSystem);
+            var mainVM = new MainViewModel(_commons, _appSettings, recentFilesHelper, _messageBoxService, _updateHelper, _localizationHelper, _fileSystem);
+
+            MainWindow = new MainWindow(_appSettings);
+            MainWindow.DataContext = mainVM;
+
+            //If language is not recognized, bring up the language selection screen
+            if (!_commons.LanguageCodeMap.ContainsKey(_appSettings.SelectedLanguage))
+            {
+                var w = new Welcome();
+                w.DataContext = mainVM.WelcomeViewModel;
+                w.ShowDialog();
+            }
+            else
+            {
+                _commons.CurrentLanguage = _appSettings.SelectedLanguage;
+            }
+
+            MainWindow.ShowDialog();
         }
     }
 }

--- a/AnnoDesigner/MainWindow.xaml.cs
+++ b/AnnoDesigner/MainWindow.xaml.cs
@@ -96,7 +96,6 @@ namespace AnnoDesigner
         private void MainWindow_DpiChanged(object sender, DpiChangedEventArgs e)
         {
             App.DpiScale = e.NewDpi;
-            //TODO: Redraw statistics when change is merged.
         }
 
         private void ToggleStatisticsView(bool showStatisticsView)

--- a/AnnoDesigner/app.manifest
+++ b/AnnoDesigner/app.manifest
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/AnnoDesigner/app.manifest
+++ b/AnnoDesigner/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="1.0.0.0" name="AnnoDesigner.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/AnnoDesigner/app.manifest
+++ b/AnnoDesigner/app.manifest
@@ -52,8 +52,8 @@
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm, true</dpiAware>
     </windowsSettings>
   </application>
   


### PR DESCRIPTION
This PR opts-in to per-monitor DPI awareness.
https://github.com/Microsoft/WPF-Samples/tree/master/PerMonitorDPI

Its not perfect on my machine, but its better than the old blurry text. When I move the window from my 4k monitor to a 1080p monitor, the window title bar extends to double height, and context menu text is much larger:
Updated:
![image](https://user-images.githubusercontent.com/48861520/91640545-3d7cf180-ea16-11ea-9e31-5cee4a09deae.png)

Original:
![image](https://user-images.githubusercontent.com/48861520/91640555-600f0a80-ea16-11ea-847f-57002c7b8033.png)

The blurry text does not show up on the images, but the overall result despite the double height title bar is much more bearable.

Additionally, this also tweaks the editor config to remove the "Object initialisation can be simplified" message (as I'm fine with either method, and it saves no lines of code nor makes anything clearer), and tweaks the App.xaml.cs file (just using pattern matching where suggested and simplifying the using statement).
