### PR TITLE
Fix 251 - NullReferenceException when changing language and Preferences window is open

### DIFF
--- a/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
@@ -109,8 +109,11 @@ namespace AnnoDesigner.ViewModels
             {
                 if (UpdateProperty(ref _selectedGridLineColor, value))
                 {
-                    UpdateGridLineColorVisibility();
-                    SaveSelectedGridLineColor();
+                    if (value != null)
+                    {
+                        UpdateGridLineColorVisibility();
+                        SaveSelectedGridLineColor();
+                    }
                 }
             }
         }
@@ -208,8 +211,11 @@ namespace AnnoDesigner.ViewModels
             {
                 if (UpdateProperty(ref _selectedObjectBorderLineColor, value))
                 {
-                    UpdateObjectBorderLineVisibility();
-                    SaveSelectedObjectBorderLine();
+                    if (value != null)
+                    {
+                        UpdateObjectBorderLineVisibility();
+                        SaveSelectedObjectBorderLine();
+                    }
                 }
             }
         }

--- a/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
@@ -148,17 +148,11 @@ namespace AnnoDesigner.ViewModels
                 return;
             }
 
-            switch (SelectedGridLineColor.Type)
+            IsGridLineColorPickerVisible = SelectedGridLineColor.Type switch
             {
-                case UserDefinedColorType.Custom:
-                    IsGridLineColorPickerVisible = true;
-                    break;
-                case UserDefinedColorType.Default:
-                case UserDefinedColorType.Light:
-                default:
-                    IsGridLineColorPickerVisible = false;
-                    break;
-            }
+                UserDefinedColorType.Custom => true,
+                _ => false,
+            };
         }
 
         private void SaveSelectedGridLineColor()
@@ -250,17 +244,11 @@ namespace AnnoDesigner.ViewModels
                 return;
             }
 
-            switch (SelectedObjectBorderLineColor.Type)
+            IsObjectBorderLineColorPickerVisible = SelectedObjectBorderLineColor.Type switch
             {
-                case UserDefinedColorType.Custom:
-                    IsObjectBorderLineColorPickerVisible = true;
-                    break;
-                case UserDefinedColorType.Default:
-                case UserDefinedColorType.Light:
-                default:
-                    IsObjectBorderLineColorPickerVisible = false;
-                    break;
-            }
+                UserDefinedColorType.Custom => true,
+                _ => false,
+            };
         }
 
         private void SaveSelectedObjectBorderLine()


### PR DESCRIPTION
Fixes #251.

The sources for the combo boxes were being cleared when the selected language was changed so they could be localised. This updated the selected values to be `null`, which fired the property changed events.