### PR TITLE
Only include supported languages in LanguageCodeMap

### DIFF
--- a/AnnoDesigner/Commons.cs
+++ b/AnnoDesigner/Commons.cs
@@ -54,11 +54,12 @@ namespace AnnoDesigner
             { "English", "eng" },
             { "Deutsch", "ger" },
             { "Français","fra" },
-            { "Español", "esp" },
-            { "Italiano", "ita" },
             { "Polski", "pol" },
             { "Русский", "rus" },
-            { "český", "cze" },
+            /* We currently do not support these languages */
+            //{ "Español", "esp" },
+            //{ "Italiano", "ita" },
+            //{ "český", "cze" },
         };
 
         public bool CanWriteInFolder(string folderPathToCheck = null)


### PR DESCRIPTION
Prevents an exception when starting the application.