### PR TITLE
Load missing settings on General Settings page

### DIFF
--- a/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/GeneralSettingsViewModel.cs
@@ -41,6 +41,9 @@ namespace AnnoDesigner.ViewModels
             UseZoomToPoint = _appSettings.UseZoomToPoint;
             ZoomSensitivityPercentage = _appSettings.ZoomSensitivityPercentage;
             HideInfluenceOnSelection = _appSettings.HideInfluenceOnSelection;
+            ShowScrollbars = _appSettings.ShowScrollbars;
+            InvertPanningDirection = _appSettings.InvertPanningDirection;
+            InvertScrollingDirection = _appSettings.InvertScrollingDirection;
 
             ResetZoomSensitivityCommand = new RelayCommand(ExecuteResetZoomSensitivity, CanExecuteResetZoomSensitivity);
 


### PR DESCRIPTION
A few checkboxes were not being repopulated when the viewmodel was being created.