### PR TITLE
Fix stale quadtree bounds after normalize

### DIFF
--- a/AnnoDesigner.Core/DataStructures/QuadTree.cs
+++ b/AnnoDesigner.Core/DataStructures/QuadTree.cs
@@ -328,6 +328,18 @@ namespace AnnoDesigner.Core.DataStructures
         }
 
         /// <summary>
+        /// Re-index the <see cref="QuadTree{T}"/> with the given func to derive bounds from <typeparamref name="T"/>. This allows us to
+        /// combine a re-index operation whilst refreshing the bounds of all the items in the QuadTree.
+        /// </summary>
+        /// <param name="boundsSelector"></param>
+        public void ReIndex(Func<T, Rect> boundsSelector)
+        {
+            var oldRoot = root;
+            root = new Quadrant(Extent);
+            AddRange(oldRoot.All().Select(_ => (_, boundsSelector(_))));
+        }
+
+        /// <summary>
         /// Create a <see cref="QuadTree{T}"/>
         /// </summary>
         /// <param name="extent">The bounds of the <see cref="QuadTree{T}"/></param>

--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -2254,7 +2254,7 @@ namespace AnnoDesigner
                 item.Position = new Point(item.Position.X - dx, item.Position.Y - dy);
             }
 
-            PlacedObjects.ReIndex();
+            PlacedObjects.ReIndex(_ => _.GridRect);
             InvalidateVisual();
             InvalidateBounds();
             InvalidateScroll();


### PR DESCRIPTION
Quick hotfix - bounds within the QuadTree were stale after calling normalize. This PR resolves that issue, and will fix #285.