### PR TITLE
Fixing #301

### DIFF
--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -436,7 +436,7 @@ namespace AnnoDesigner.Models
             {
                 if (_gridInfluenceRangeRect == default)
                 {
-                    if (WrappedAnnoObject.InfluenceRange == 0)
+                    if (WrappedAnnoObject.InfluenceRange <= 0)
                     {
                         _gridInfluenceRangeRect = new Rect(Position, default(Size));
                     }


### PR DESCRIPTION
Fixing the error that could crash program, when influence is -2
Saves will still have the -2 numbers, but it will  be ignored by the drawing of the true influence distance