### PR TITLE
Fixing issue #299

### DIFF
--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -374,10 +374,10 @@ namespace AnnoDesigner.Models
         {
             if (_screenRadius == default || _lastGridSizeForScreenRadius != gridSize)
             {
-                // Anno odd number buildings (3x3/3x5 etc) draw the Circle range with a +0.5 grid circles, this is not correct vs and need
+                // Anno odd number buildings (3x3/3x5 etc) draw the Circle range with a +0.5 grid, this is not correct vs Game and need
                 // to be adjust to get the right Circle Range in the tool for those buildings.
                 // Because of this change it will also work on 2070, and 1800 circle range buildings. If this will cause problems on the
-                //  right grid size range then wee need an WrapperAnnoObject.Header label (that where Anno 1404 is stand) to get this right
+                // right grid size range then wee need an WrapperAnnoObject.Header label (that where Anno 1404 is stand) to get this right
                 // Issue #299 (13-10-2020) 
 
                 // To get Round up numbers, like 1.5 becomes 1.0 , 2.25 becomes 2.00

--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -374,8 +374,19 @@ namespace AnnoDesigner.Models
         {
             if (_screenRadius == default || _lastGridSizeForScreenRadius != gridSize)
             {
-                _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius, gridSize);
-
+                // Anno 1404 odd number buildings (3x3/3x5 etc) the Circle range draw a +0.5 grid circles, this is notcorrect and need to be adjust
+                // to get the right Circle Range for those buildings.
+                // Because of this change it will also work on 2070, and 1800 circle range buildings if this will cause problems on the right grid size range
+                // then wee need an WrapperAnnoObject.Header label (that where Anno 1404 is stand) to get this right
+                // Issue #299
+                if ((WrappedAnnoObject.Size.Width == 3 || WrappedAnnoObject.Size.Width == 5 || WrappedAnnoObject.Size.Width == 7 || WrappedAnnoObject.Size.Width == 9) && (WrappedAnnoObject.Size.Height == 3 || WrappedAnnoObject.Size.Height == 5 || WrappedAnnoObject.Size.Height == 7 || WrappedAnnoObject.Size.Height == 9))
+                {
+                    _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius - 0.5, gridSize);
+                }
+                else
+                {
+                    _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius, gridSize);
+                }
                 _lastGridSizeForScreenRadius = gridSize;
             }
 

--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -374,12 +374,9 @@ namespace AnnoDesigner.Models
         {
             if (_screenRadius == default || _lastGridSizeForScreenRadius != gridSize)
             {
-                // Anno odd number buildings (3x3/3x5 etc) draw the Circle range with a +0.5 grid, this is not correct vs Game and need
-                // to be adjust to get the right Circle Range in the tool for those buildings.
-                // Because of this change it will also work on 2070, and 1800 circle range buildings. If this will cause problems on the
-                // right grid size range then wee need an WrapperAnnoObject.Header label (that where Anno 1404 is stand) to get this right
-                // Issue #299 (13-10-2020) 
-
+                // Buildings of an odd-numbered size (3x3/3x5 etc) draw their circular influence range with an additional +0.5, this is not correct and needs
+                // to be adjusted to produce the correct radius for those buildings.
+                
                 // To get Round up numbers, like 1.5 becomes 1.0 , 2.25 becomes 2.00
                 double tempMathX = Math.Floor(WrappedAnnoObject.Size.Width / 2);
                 double tempMathY = Math.Floor(WrappedAnnoObject.Size.Height / 2);

--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -374,12 +374,18 @@ namespace AnnoDesigner.Models
         {
             if (_screenRadius == default || _lastGridSizeForScreenRadius != gridSize)
             {
-                // Anno 1404 odd number buildings (3x3/3x5 etc) the Circle range draw a +0.5 grid circles, this is notcorrect and need to be adjust
-                // to get the right Circle Range for those buildings.
-                // Because of this change it will also work on 2070, and 1800 circle range buildings if this will cause problems on the right grid size range
-                // then wee need an WrapperAnnoObject.Header label (that where Anno 1404 is stand) to get this right
-                // Issue #299
-                if ((WrappedAnnoObject.Size.Width == 3 || WrappedAnnoObject.Size.Width == 5 || WrappedAnnoObject.Size.Width == 7 || WrappedAnnoObject.Size.Width == 9) && (WrappedAnnoObject.Size.Height == 3 || WrappedAnnoObject.Size.Height == 5 || WrappedAnnoObject.Size.Height == 7 || WrappedAnnoObject.Size.Height == 9))
+                // Anno odd number buildings (3x3/3x5 etc) draw the Circle range with a +0.5 grid circles, this is not correct vs and need
+                // to be adjust to get the right Circle Range in the tool for those buildings.
+                // Because of this change it will also work on 2070, and 1800 circle range buildings. If this will cause problems on the
+                //  right grid size range then wee need an WrapperAnnoObject.Header label (that where Anno 1404 is stand) to get this right
+                // Issue #299 (13-10-2020) 
+
+                // To get Round up numbers, like 1.5 becomes 1.0 , 2.25 becomes 2.00
+                double tempMathX = Math.Floor(WrappedAnnoObject.Size.Width / 2);
+                double tempMathY = Math.Floor(WrappedAnnoObject.Size.Height / 2);
+
+                // check if Object Width and Height are odd numbers or not, if both are, adjust the circle size with -0.5
+                if ((WrappedAnnoObject.Size.Width /2 > tempMathX) && (WrappedAnnoObject.Size.Height/2 > tempMathY)) 
                 {
                     _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius - 0.5, gridSize);
                 }

--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -377,13 +377,9 @@ namespace AnnoDesigner.Models
                 // Buildings of an odd-numbered size (3x3/3x5 etc) draw their circular influence range with an additional +0.5,
                 // this is not correct and needs to be adjusted to produce the correct radius for those buildings.
                 // See https://github.com/AnnoDesigner/anno-designer/issues/299 for an explanation of the issue.
-                
-                // To get Round up numbers, like 1.5 becomes 1.0 , 2.25 becomes 2.00
-                double tempMathX = Math.Floor(WrappedAnnoObject.Size.Width / 2);
-                double tempMathY = Math.Floor(WrappedAnnoObject.Size.Height / 2);
 
                 // check if Object Width and Height are odd numbers or not, if both are, adjust the circle size with -0.5
-                if ((WrappedAnnoObject.Size.Width /2 > tempMathX) && (WrappedAnnoObject.Size.Height/2 > tempMathY)) 
+                if ((WrappedAnnoObject.Size.Width %2 != 0 ) && (WrappedAnnoObject.Size.Height %2 != 0)) 
                 {
                     _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius - 0.1, gridSize);
                 }

--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -387,7 +387,7 @@ namespace AnnoDesigner.Models
                 // check if Object Width and Height are odd numbers or not, if both are, adjust the circle size with -0.5
                 if ((WrappedAnnoObject.Size.Width /2 > tempMathX) && (WrappedAnnoObject.Size.Height/2 > tempMathY)) 
                 {
-                    _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius - 0.5, gridSize);
+                    _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius - 0.1, gridSize);
                 }
                 else
                 {
@@ -453,7 +453,7 @@ namespace AnnoDesigner.Models
             {
                 if (_gridInfluenceRangeRect == default)
                 {
-                    if (WrappedAnnoObject.InfluenceRange == 0)
+                    if (WrappedAnnoObject.InfluenceRange <= 0)
                     {
                         _gridInfluenceRangeRect = new Rect(Position, default(Size));
                     }

--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -378,7 +378,7 @@ namespace AnnoDesigner.Models
                 // this is not correct and needs to be adjusted to produce the correct radius for those buildings.
                 // See https://github.com/AnnoDesigner/anno-designer/issues/299 for an explanation of the issue.
 
-                // check if Object Width and Height are odd numbers or not, if both are, adjust the circle size with -0.5
+                // check if Object Width and Height are odd numbers or not, if both are, adjust the circle size with -0.1
                 if ((WrappedAnnoObject.Size.Width %2 != 0 ) && (WrappedAnnoObject.Size.Height %2 != 0)) 
                 {
                     _screenRadius = _coordinateHelper.GridToScreen(WrappedAnnoObject.Radius - 0.1, gridSize);

--- a/AnnoDesigner/Models/LayoutObject.cs
+++ b/AnnoDesigner/Models/LayoutObject.cs
@@ -374,8 +374,9 @@ namespace AnnoDesigner.Models
         {
             if (_screenRadius == default || _lastGridSizeForScreenRadius != gridSize)
             {
-                // Buildings of an odd-numbered size (3x3/3x5 etc) draw their circular influence range with an additional +0.5, this is not correct and needs
-                // to be adjusted to produce the correct radius for those buildings.
+                // Buildings of an odd-numbered size (3x3/3x5 etc) draw their circular influence range with an additional +0.5,
+                // this is not correct and needs to be adjusted to produce the correct radius for those buildings.
+                // See https://github.com/AnnoDesigner/anno-designer/issues/299 for an explanation of the issue.
                 
                 // To get Round up numbers, like 1.5 becomes 1.0 , 2.25 becomes 2.00
                 double tempMathX = Math.Floor(WrappedAnnoObject.Size.Width / 2);

--- a/Tests/AnnoDesigner.Tests/LayoutObjectTests.cs
+++ b/Tests/AnnoDesigner.Tests/LayoutObjectTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using AnnoDesigner.Core.Models;
+using AnnoDesigner.Helper;
+using AnnoDesigner.Models;
+using Xunit;
+
+namespace AnnoDesigner.Tests
+{
+    public class LayoutObjectTests
+    {
+        private static readonly ICoordinateHelper coordinateHelper;
+
+        static LayoutObjectTests()
+        {
+            coordinateHelper = new CoordinateHelper();
+        }
+
+        #region GridInfluenceRangeRect tests
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-0.001)]
+        public void GridInfluenceRangeRect_InfluenceRangeIsZeroOrNegative_ShouldReturnEmptyRect(double influenceRangeToSet)
+        {
+            // Arrange
+            var annoObject = new AnnoObject
+            {
+                InfluenceRange = influenceRangeToSet,
+                Size = new Size(10, 10),
+                Position = new Point(42, 42)
+            };
+            var layoutObject = new LayoutObject(annoObject, null, null, null);
+
+            // Act
+            var influenceRangeRect = layoutObject.GridInfluenceRangeRect;
+
+            // Assert
+            Assert.Equal(annoObject.Position, influenceRangeRect.Location);
+            Assert.Equal(default(Size), influenceRangeRect.Size);
+        }
+
+        #endregion
+
+        #region GetScreenRadius tests
+
+        [Theory]
+        [InlineData(5, 5, 99)]
+        [InlineData(3, 3, 99)]
+        [InlineData(5.5, 5.5, 99)]
+        public void GetScreenRadius_SizeHeightAndWidthAreOdd_ShouldAdjustRadius(double widthToSet, double heightToSet, double expectedRadius)
+        {
+            // Arrange            
+            var annoObject = new AnnoObject
+            {
+                Size = new Size(widthToSet, heightToSet),
+                Radius = 10
+            };
+            var layoutObject = new LayoutObject(annoObject, coordinateHelper, null, null);
+
+            // Act
+            var screenRadius = layoutObject.GetScreenRadius(10);
+
+            // Assert
+            Assert.Equal(expectedRadius, screenRadius);
+        }
+
+        [Fact]
+        public void GetScreenRadius_SizeHeightIsOdd_ShouldNotAdjustRadius()
+        {
+            // Arrange            
+            var annoObject = new AnnoObject
+            {
+                Size = new Size(8, 5),
+                Radius = 10
+            };
+            var layoutObject = new LayoutObject(annoObject, coordinateHelper, null, null);
+
+            // Act
+            var screenRadius = layoutObject.GetScreenRadius(10);
+
+            // Assert
+            Assert.Equal(100, screenRadius);
+        }
+
+        [Fact]
+        public void GetScreenRadius_SizeWidthIsOdd_ShouldNotAdjustRadius()
+        {
+            // Arrange            
+            var annoObject = new AnnoObject
+            {
+                Size = new Size(5, 8),
+                Radius = 10
+            };
+            var layoutObject = new LayoutObject(annoObject, coordinateHelper, null, null);
+
+            // Act
+            var screenRadius = layoutObject.GetScreenRadius(10);
+
+            // Assert
+            Assert.Equal(100, screenRadius);
+        }
+
+        [Fact]
+        public void GetScreenRadius_NeitherSizeWidthNorHeightIsOdd_ShouldNotAdjustRadius()
+        {
+            // Arrange            
+            var annoObject = new AnnoObject
+            {
+                Size = new Size(8, 8),
+                Radius = 10
+            };
+            var layoutObject = new LayoutObject(annoObject, coordinateHelper, null, null);
+
+            // Act
+            var screenRadius = layoutObject.GetScreenRadius(10);
+
+            // Assert
+            Assert.Equal(100, screenRadius);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Change Circle Range Behavior for Odd number buildings (3x3/3x5 etc) to get rid of the half grid drawing that is not correct vs game circle ranges