### PR TITLE
Fix no auto download of presets at startup

### DIFF
--- a/AnnoDesigner/ViewModels/UpdateSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/UpdateSettingsViewModel.cs
@@ -145,6 +145,9 @@ namespace AnnoDesigner.ViewModels
             var isNewReleaseAvailable = foundRelease.Version > new Version(PresetsVersionValue);
             if (isNewReleaseAvailable)
             {
+                IsPresetUpdateAvailable = true;
+                FoundPresetRelease = foundRelease;
+
                 if (isAutomaticUpdateCheck)
                 {
                     if (_messageBoxService.ShowQuestion(Application.Current.MainWindow,
@@ -153,11 +156,6 @@ namespace AnnoDesigner.ViewModels
                     {
                         ExecuteDownloadPresets(null);
                     }
-                }
-                else
-                {
-                    IsPresetUpdateAvailable = true;
-                    FoundPresetRelease = foundRelease;
                 }
             }
         }


### PR DESCRIPTION
This PR fixes an issue that prevents the download of new presets at application startup.
The download/update via the `Preferences` window doesn't have this issue.