### PR TITLE
Adjust build script to new version format

### DIFF
--- a/AnnoDesigner.Core/Properties/AssemblyInfo.cs
+++ b/AnnoDesigner.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.4.0.0")]
-[assembly: AssemblyFileVersion("8.4.0.0")]
+// Version("1.0.*")]
+[assembly: AssemblyVersion("8.81.0.0")]
+[assembly: AssemblyFileVersion("8.81.0.0")]

--- a/build/build.cake
+++ b/build/build.cake
@@ -2,7 +2,7 @@
 const string xunitRunnerVersion = "2.4.1";
 #tool nuget:?package=xunit.runner.console&version=2.4.1
 #tool nuget:?package=OpenCover&version=4.7.922
-#tool nuget:?package=ReportGenerator&version=4.6.1
+#tool nuget:?package=ReportGenerator&version=4.7.1
 
 ///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -125,16 +125,27 @@ var updateAssemblyInfoTask = Task("Update-Assembly-Info")
                         "(?<=AssemblyFileVersion\\(\")(.+?)(?=\"\\))",
                         $"{versionNumber}.0.0");
 
+    ReplaceRegexInFiles("./../AnnoDesigner.Core/Properties/AssemblyInfo.cs",
+                        "(?<=AssemblyVersion\\(\")(.+?)(?=\"\\))",
+                        $"{versionNumber}.0.0");
+    ReplaceRegexInFiles("./../AnnoDesigner.Core/Properties/AssemblyInfo.cs",
+                        "(?<=AssemblyFileVersion\\(\")(.+?)(?=\"\\))",
+                        $"{versionNumber}.0.0");
+
     ReplaceRegexInFiles("./../PresetParser/Properties/AssemblyInfo.cs",
                         "(?<=AssemblyVersion\\(\")(.+?)(?=\"\\))",
                         $"{versionNumber}.0.0");
     ReplaceRegexInFiles("./../PresetParser/Properties/AssemblyInfo.cs",
                         "(?<=AssemblyFileVersion\\(\")(.+?)(?=\"\\))",
                         $"{versionNumber}.0.0");
-    
+
     ReplaceRegexInFiles("./../AnnoDesigner/Constants.cs",
-                        "(?<=double Version = )(\\d.\\d)",
+                        "(?<= new Version\\()(.+?)(?=\\);)",
                         $"{versionNumber}");
+    //Replace dot (.) with comma (,)
+    ReplaceRegexInFiles("./../AnnoDesigner/Constants.cs",
+                        "(?<=new Version\\([1-9]{1})([.])(?=[0-9]+\\);)",
+                        ", ");
 });
 
 var buildTask = Task("Build")

--- a/build/tools/packages.config
+++ b/build/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.35" />	
+    <package id="Cake" version="0.38.5" />	
 </packages>


### PR DESCRIPTION
This PR adjusts the build script to the new version format (`Version` vs `double`). Also the dependencies were updated.
The missing adjustment of `AssemblyInfo` inside `AnnoDesigner.Core` was also fixed.