### PR TITLE
Change "Unknown Object" Behavior.

### DIFF
--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -469,6 +469,12 @@
                                      Text="{Binding BuildingSettingsViewModel.BuildingIdentifier}"
                                      Visibility="Collapsed"
                                      Width="140" />
+                            <TextBox DockPanel.Dock="Right"
+                                     Height="10"
+                                     IsEnabled="False"
+                                     Text="{Binding BuildingSettingsViewModel.BuildingRealName}"
+                                     Visibility="Collapsed"
+                                     Width="140" />
                         </DockPanel>
                         <DockPanel LastChildFill="False"
                                    Height="46">

--- a/AnnoDesigner/ViewModels/BuildingSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/BuildingSettingsViewModel.cs
@@ -26,6 +26,7 @@ namespace AnnoDesigner.ViewModels
         private int _buildingWidth;
         private string _buildingTemplate;
         private string _buildingName;
+        private string _buildingRealName;
         private string _buildingIdentifier;
         private double _buildingRadius;
         private double _buildingInfluenceRange;
@@ -126,6 +127,12 @@ namespace AnnoDesigner.ViewModels
         {
             get { return _buildingName; }
             set { UpdateProperty(ref _buildingName, value); }
+        }
+
+        public string BuildingRealName
+        {
+            get { return _buildingRealName; }
+            set { UpdateProperty(ref _buildingRealName, value); }
         }
 
         public string BuildingIdentifier

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using AnnoDesigner.Core;
@@ -322,6 +323,7 @@ namespace AnnoDesigner.ViewModels
         {
             // parse user inputs and create new object
             string RenameBuildingIdentifier = BuildingSettingsViewModel.BuildingName;
+            string TextBoxText = "TextBox";
             var obj = new AnnoObject
             {
                 Size = new Size(BuildingSettingsViewModel.BuildingWidth, BuildingSettingsViewModel.BuildingHeight),
@@ -373,8 +375,23 @@ namespace AnnoDesigner.ViewModels
                                 obj.Identifier = buildingInfo.Identifier;
                                 if (BuildingSettingsViewModel.BuildingRealName != RenameBuildingIdentifier)
                                 {
-                                    obj.Identifier = RenameBuildingIdentifier;
-                                    obj.Template = RenameBuildingIdentifier;
+                                    if (BuildingSettingsViewModel.IsEnableLabelChecked)
+                                    {
+                                        if (RenameBuildingIdentifier.Length > 30)
+                                        {
+                                            obj.Identifier = TextBoxText;
+                                            obj.Template = TextBoxText;
+                                        }
+                                        else
+                                        {
+                                            //Keep label, tempate and identifiername
+                                        }
+                                    }
+                                    else
+                                    {
+                                        obj.Identifier = RenameBuildingIdentifier;
+                                        obj.Template = RenameBuildingIdentifier;
+                                    }
                                 }
                             }
                             //If one of the other world residents then the OW Residents in Anno 1800 are renamed to other tiers names rename them. 
@@ -427,9 +444,25 @@ namespace AnnoDesigner.ViewModels
                 }
                 if (string.IsNullOrEmpty(obj.Icon) && !BuildingSettingsViewModel.BuildingTemplate.Contains("field", StringComparison.OrdinalIgnoreCase))
                 {
-                    //obj.Identifier = "Unknown Object";
-                    obj.Identifier = RenameBuildingIdentifier;
-                    obj.Template = RenameBuildingIdentifier;
+                    if (BuildingSettingsViewModel.IsEnableLabelChecked)
+                    {
+                        if (RenameBuildingIdentifier.Length > 30)
+                        {
+                            obj.Identifier = TextBoxText;
+                            obj.Template = TextBoxText;
+                        }
+                        else
+                        {
+                            obj.Identifier = RenameBuildingIdentifier;
+                            obj.Template = RenameBuildingIdentifier;
+                        }
+                    } 
+                    else
+                    {
+                        //obj.Identifier = "Unknown Object";
+                        obj.Identifier = RenameBuildingIdentifier;
+                        obj.Template = RenameBuildingIdentifier;
+                    }
                 }
 
                 AnnoCanvas.SetCurrentObject(new LayoutObject(obj, _coordinateHelper, _brushCache, _penCache));

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -321,6 +321,7 @@ namespace AnnoDesigner.ViewModels
         private void ApplyCurrentObject()
         {
             // parse user inputs and create new object
+            string RenameBuildingIdentifier = BuildingSettingsViewModel.BuildingName;
             var obj = new AnnoObject
             {
                 Size = new Size(BuildingSettingsViewModel.BuildingWidth, BuildingSettingsViewModel.BuildingHeight),
@@ -366,20 +367,36 @@ namespace AnnoDesigner.ViewModels
                             || (obj.Size.Height == buildingInfo.BuildBlocker["x"] && obj.Size.Width == buildingInfo.BuildBlocker["z"]))
                         {
                             //if sizes match and icon is a existing building in the presets, call it that object
-                            if (obj.Identifier != "Residence_New_World")
+                            //Exception are all other Residences of Anno 1800, that change back to Farmer Resident names
+                            if (obj.Identifier != "Residence_New_World" && obj.Identifier != "Residence_Arctic_World" && obj.Identifier != "Residence_Africa_World")
                             {
                                 obj.Identifier = buildingInfo.Identifier;
+                                if (BuildingSettingsViewModel.BuildingRealName != RenameBuildingIdentifier)
+                                {
+                                    obj.Identifier = RenameBuildingIdentifier;
+                                    obj.Template = RenameBuildingIdentifier;
+                                }
+                            }
+                            //If one of the other world residents then the OW Residents in Anno 1800 are renamed to other tiers names rename them. 
+                            if ((obj.Identifier == "Residence_New_World" || obj.Identifier == "Residence_Arctic_World" || obj.Identifier == "Residence_Africa_World") && BuildingSettingsViewModel.BuildingRealName != RenameBuildingIdentifier)
+                            {
+                                obj.Identifier = RenameBuildingIdentifier;
+                                obj.Template = RenameBuildingIdentifier;
                             }
                         }
                         else
                         {
                             //Sizes and icon do not match
-                            obj.Identifier = "Unknown Object";
+                            //obj.Identifier = "Unknown Object";
+                            obj.Identifier = RenameBuildingIdentifier;
+                            obj.Template = RenameBuildingIdentifier;
                         }
                     }
                     else if (!BuildingSettingsViewModel.BuildingTemplate.Contains("field", StringComparison.OrdinalIgnoreCase)) //check if the icon is removed from a template field
                     {
-                        obj.Identifier = "Unknown Object";
+                        //obj.Identifier = "Unknown Object";
+                        obj.Identifier = RenameBuildingIdentifier;
+                        obj.Template = RenameBuildingIdentifier;
                     }
                 }
                 else if (!string.IsNullOrWhiteSpace(obj.Icon) && obj.Icon.Contains(IconFieldNamesCheck))
@@ -403,12 +420,16 @@ namespace AnnoDesigner.ViewModels
                     }
                     else
                     {
-                        obj.Identifier = "Unknown Object";
+                        //obj.Identifier = "Unknown Object";
+                        obj.Identifier = RenameBuildingIdentifier;
+                        obj.Template = RenameBuildingIdentifier;
                     }
                 }
                 if (string.IsNullOrEmpty(obj.Icon) && !BuildingSettingsViewModel.BuildingTemplate.Contains("field", StringComparison.OrdinalIgnoreCase))
                 {
-                    obj.Identifier = "Unknown Object";
+                    //obj.Identifier = "Unknown Object";
+                    obj.Identifier = RenameBuildingIdentifier;
+                    obj.Template = RenameBuildingIdentifier;
                 }
 
                 AnnoCanvas.SetCurrentObject(new LayoutObject(obj, _coordinateHelper, _brushCache, _penCache));
@@ -438,6 +459,7 @@ namespace AnnoDesigner.ViewModels
             BuildingSettingsViewModel.SelectedColor = layoutObject.Color;
             // label
             BuildingSettingsViewModel.BuildingName = obj.Label;
+            BuildingSettingsViewModel.BuildingRealName = obj.Label;
             // Identifier
             BuildingSettingsViewModel.BuildingIdentifier = layoutObject.Identifier;
             // Template

--- a/AnnoDesigner/ViewModels/StatisticsViewModel.cs
+++ b/AnnoDesigner/ViewModels/StatisticsViewModel.cs
@@ -201,10 +201,17 @@ namespace AnnoDesigner.ViewModels
                     }
                     else
                     {
-                        item.ElementAt(0).Identifier = "";
+                        /// Ruled those 2 out to keep Building Name Changes done through the Labeling of the building
+                        /// and when the building is not in the preset. Those statisticBuildings.name will not translated to
+                        /// other luangages anymore, as users can give there own names.
+                        /// However i made it so, that if localizations get those translations, it will translated.
+                        /// 06-02-2021, on request of user(s) on Discord read this on
+                        /// https://discord.com/channels/571011757317947406/571011757317947410/800118895855665203
+                        //item.ElementAt(0).Identifier = "";
+                        //statisticBuilding.Name = _localizationHelper.GetLocalization("StatNameNotFound");
 
                         statisticBuilding.Count = item.Count();
-                        statisticBuilding.Name = _localizationHelper.GetLocalization("StatNameNotFound");
+                        statisticBuilding.Name = _localizationHelper.GetLocalization(item.ElementAt(0).Identifier);
                     }
                 }
                 else


### PR DESCRIPTION
Made hidden TextBox named BuildingRealName for the following:
User can change the Building Names (for objects and statisitcBuilding.Name), and when they do, Identifier and Template Names will be changed into this name
"Building name not fount" will only be there if there is something really wrong.
Fix wrongly named Residences of Embesa and Arctic Anno 1800