### PR TITLE
Show tree node if header matches search text

### DIFF
--- a/AnnoDesigner/ViewModels/PresetsTreeViewModel.cs
+++ b/AnnoDesigner/ViewModels/PresetsTreeViewModel.cs
@@ -528,11 +528,27 @@ namespace AnnoDesigner.ViewModels
                 }
             }
 
-            //no child matches -> hide item
+            //no child matches -> check if header of current node is matching
             if (!anyChildMatches)
             {
-                curItem.IsVisible = false;
-                curItem.IsExpanded = false;
+                var currentHeaderMatches = curItem.Header.Contains(FilterText, StringComparison.OrdinalIgnoreCase);
+                if (currentHeaderMatches)
+                {
+                    foreach (var curChild in curItem.Children)
+                    {
+                        curChild.IsVisible = true;
+                    }
+
+                    curItem.IsVisible = true;
+                    //do not expand to avoid clutter in the view
+                    curItem.IsExpanded = false;
+                }
+                //no child matches -> hide item
+                else
+                {
+                    curItem.IsVisible = false;
+                    curItem.IsExpanded = false;
+                }
             }
             else
             {


### PR DESCRIPTION
This PR tweaks the search to check the header of the nodes when searching.
Before if there was no child matching the search the node was hidden.
After if there is no child matching the search the node is visible. To avoid cluttering the tree the node is not expanded.

If there is a demand to not check the header it is possible to add a new option to the preferences window.

### Before:
![before](https://user-images.githubusercontent.com/6222752/120193542-dac2bb80-c21c-11eb-87c8-8f23c5506036.gif)

### After:
![after](https://user-images.githubusercontent.com/6222752/120193591-e4e4ba00-c21c-11eb-9746-5250f0e39fb9.gif)