### PR TITLE
Replace LINQ with simple loop in hot path

### DIFF
--- a/AnnoDesigner.Core/DataStructures/QuadTree.cs
+++ b/AnnoDesigner.Core/DataStructures/QuadTree.cs
@@ -64,7 +64,7 @@ namespace AnnoDesigner.Core.DataStructures
                 isDirty = false;
 
                 var w = Extent.Width / 2;
-                var h = Extent.Width / 2;
+                var h = Extent.Height / 2;
 
                 topRightBounds = new Rect(Extent.Left + w, Extent.Top, w, h);
                 topLeftBounds = new Rect(Extent.Left, Extent.Top, w, h);
@@ -152,20 +152,35 @@ namespace AnnoDesigner.Core.DataStructures
                 {
                     topRight.GetItemsIntersecting(items, bounds);
                 }
+
                 if (topLeft != null && topLeft.Extent.IntersectsWith(bounds))
                 {
                     topLeft.GetItemsIntersecting(items, bounds);
                 }
+
                 if (bottomRight != null && bottomRight.Extent.IntersectsWith(bounds))
                 {
                     bottomRight.GetItemsIntersecting(items, bounds);
                 }
+
                 if (bottomLeft != null && bottomLeft.Extent.IntersectsWith(bounds))
                 {
                     bottomLeft.GetItemsIntersecting(items, bounds);
                 }
+
                 //add all the items in this quadrant that intersect the given bounds
-                items.AddRange(ItemsInQuadrant.Where(_ => _.Bounds.IntersectsWith(bounds)).Select(_ => _.Item));
+                items.AddRange(GetIntersectingItmesInQuadrant(bounds));
+            }
+
+            private IEnumerable<T> GetIntersectingItmesInQuadrant(Rect boundsToCheck)
+            {
+                foreach (var (Item, Bounds) in ItemsInQuadrant)
+                {
+                    if (Bounds.IntersectsWith(boundsToCheck))
+                    {
+                        yield return Item;
+                    }
+                }
             }
 
             /// <summary>


### PR DESCRIPTION
This PR replaces LINQ in the hot path `QuadTree.GetItemsIntersecting(List<T> items, Rect bounds)` with a simple loop to reduce allocations.
Also a typo in `QuadTree.Quadrant(Rect extent)` is fixed.