### PR TITLE
Update version numbers for release of 9.1

### DIFF
--- a/AnnoDesigner.Core/Properties/AssemblyInfo.cs
+++ b/AnnoDesigner.Core/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("AnnoDesigner.Core")]
-[assembly: AssemblyCopyright("Copyright © 2020")]
+[assembly: AssemblyCopyright("Copyright © 2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // Version("1.0.*")]
-[assembly: AssemblyVersion("8.81.0.0")]
-[assembly: AssemblyFileVersion("8.81.0.0")]
+[assembly: AssemblyVersion("9.1.0.0")]
+[assembly: AssemblyFileVersion("9.1.0.0")]

--- a/AnnoDesigner/Constants.cs
+++ b/AnnoDesigner/Constants.cs
@@ -15,7 +15,7 @@ namespace AnnoDesigner
         /// <remarks>To support old(er) versions of the app, there should be an agreement to just use major.minor for the version and just increment the minor value.
         /// At least for some time.
         /// This limits the possible versions to 255.255.</remarks>
-        public static readonly Version Version = new Version(8, 81);
+        public static readonly Version Version = new Version(9, 1);
 
         /// <summary>
         /// The minimal grid size to which the user can zoom out.

--- a/AnnoDesigner/Properties/AssemblyInfo.cs
+++ b/AnnoDesigner/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("AnnoDesigner")]
-[assembly: AssemblyCopyright("Copyright © 2020")]
+[assembly: AssemblyCopyright("Copyright © 2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -51,5 +51,5 @@ using System.Windows;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("8.81.0.0")]
-[assembly: AssemblyFileVersion("8.81.0.0")]
+[assembly: AssemblyVersion("9.1.0.0")]
+[assembly: AssemblyFileVersion("9.1.0.0")]

--- a/PresetParser/Properties/AssemblyInfo.cs
+++ b/PresetParser/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PresetParser")]
-[assembly: AssemblyCopyright("Copyright © 2013-2020")]
+[assembly: AssemblyCopyright("Copyright © 2013-2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("8.81.0.0")]
-[assembly: AssemblyFileVersion("8.81.0.0")]
+[assembly: AssemblyVersion("9.1.0.0")]
+[assembly: AssemblyFileVersion("9.1.0.0")]


### PR DESCRIPTION
This PR updates all relevant version numbers for release 9.1 (without triggering auto-uupdate and updating the main ReadMe).