### PR TITLE
🧹 Remove unnecessary entries in .csproj

### DIFF
--- a/AnnoDesigner.Core/AnnoDesigner.Core.csproj
+++ b/AnnoDesigner.Core/AnnoDesigner.Core.csproj
@@ -12,10 +12,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.7.8" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.25" />
   </ItemGroup>
 </Project>

--- a/PresetParser/PresetParser.csproj
+++ b/PresetParser/PresetParser.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AnnoDesigner.Core\AnnoDesigner.Core.csproj" />

--- a/Tests/AnnoDesigner.Core.Tests/AnnoDesigner.Core.Tests.csproj
+++ b/Tests/AnnoDesigner.Core.Tests/AnnoDesigner.Core.Tests.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\Presets\treeLocalization.json" Link="Testdata\TreeLocalization\treeLocalization.json">
@@ -12,9 +12,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.25" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />

--- a/Tests/AnnoDesigner.Tests/AnnoDesigner.Tests.csproj
+++ b/Tests/AnnoDesigner.Tests/AnnoDesigner.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Reference Update="WindowsBase">
@@ -11,9 +12,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.25" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />

--- a/Tests/PresetParser.Tests/PresetParser.Tests.csproj
+++ b/Tests/PresetParser.Tests/PresetParser.Tests.csproj
@@ -3,12 +3,10 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.25" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />


### PR DESCRIPTION
This PR removes some unnecessary entries inside the `.csproj` files.
Most of them are left overs from the conversion to the new SDK style project files.