### PR TITLE
Disable access key for recent file paths in menu

### DIFF
--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -97,8 +97,13 @@
                               IsEnabled="{Binding HasRecentFiles}">
                         <MenuItem.ItemContainerStyle>
                             <Style TargetType="MenuItem">
-                                <Setter Property="Header"
-                                        Value="{Binding Path}" />
+                                <Setter Property="HeaderTemplate">
+                                    <Setter.Value>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Path, Mode=OneTime}" />
+                                        </DataTemplate>
+                                    </Setter.Value>
+                                </Setter>
                                 <Setter Property="Command"
                                         Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Path=DataContext.OpenRecentFileCommand}" />
                                 <Setter Property="CommandParameter"


### PR DESCRIPTION
This PR fixes an issue with access keys or [mnemonics](https://en.wikipedia.org/wiki/Mnemonics_(keyboard)) in the `Recent files` menu.

#### before

![accesskey_before](https://user-images.githubusercontent.com/6222752/136538278-eb56b3b0-78cf-49c4-a079-1d3f78ac62d5.png)

#### after

![accesskey_after](https://user-images.githubusercontent.com/6222752/136538308-b5ab4266-ed0f-49d1-882f-5efa962161e0.png)