### PR TITLE
Fix crash when exporting image with selection

### DIFF
--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -1349,7 +1349,11 @@ namespace AnnoDesigner.ViewModels
                     PlacedObjects = quadTree,
                     RenderGrid = AnnoCanvas.RenderGrid,
                     RenderIcon = AnnoCanvas.RenderIcon,
-                    RenderLabel = AnnoCanvas.RenderLabel
+                    RenderLabel = AnnoCanvas.RenderLabel,
+                    RenderHarborBlockedArea = AnnoCanvas.RenderHarborBlockedArea,
+                    RenderPanorama = AnnoCanvas.RenderPanorama,
+                    RenderTrueInfluenceRange = AnnoCanvas.RenderTrueInfluenceRange,
+                    RenderInfluences = AnnoCanvas.RenderInfluences,
                 };
 
                 sw.Stop();
@@ -1357,11 +1361,13 @@ namespace AnnoDesigner.ViewModels
 
                 // normalize layout
                 target.Normalize(border);
+
                 // set zoom level
                 if (exportZoom)
                 {
                     target.GridSize = AnnoCanvas.GridSize;
                 }
+
                 // set selection
                 if (exportSelection)
                 {
@@ -1390,7 +1396,7 @@ namespace AnnoDesigner.ViewModels
                 if (renderStatistics)
                 {
                     var exportStatisticsViewModel = new StatisticsViewModel(_localizationHelper, _commons);
-                    exportStatisticsViewModel.UpdateStatisticsAsync(UpdateMode.All, target.PlacedObjects.ToList(), target.SelectedObjects, target.BuildingPresets).GetAwaiter().GetResult(); ;
+                    exportStatisticsViewModel.UpdateStatisticsAsync(UpdateMode.All, target.PlacedObjects.ToList(), target.SelectedObjects, target.BuildingPresets).GetAwaiter().GetResult();
                     exportStatisticsViewModel.ShowBuildingList = StatisticsViewModel.ShowBuildingList;
 
                     var exportStatisticsView = new StatisticsView()

--- a/AnnoDesigner/ViewModels/StatisticsViewModel.cs
+++ b/AnnoDesigner/ViewModels/StatisticsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -24,7 +25,7 @@ namespace AnnoDesigner.ViewModels
         private ObservableCollection<StatisticsBuilding> _buildings;
         private ObservableCollection<StatisticsBuilding> _selectedBuildings;
         private StatisticsCalculationHelper _statisticsCalculationHelper;
-        private readonly Dictionary<string, BuildingInfo> _cachedPresetsBuilding;
+        private readonly ConcurrentDictionary<string, BuildingInfo> _cachedPresetsBuilding;
         private readonly ILocalizationHelper _localizationHelper;
         private readonly ICommons _commons;
 
@@ -43,7 +44,7 @@ namespace AnnoDesigner.ViewModels
             Buildings = new ObservableCollection<StatisticsBuilding>();
             SelectedBuildings = new ObservableCollection<StatisticsBuilding>();
             _statisticsCalculationHelper = new StatisticsCalculationHelper();
-            _cachedPresetsBuilding = new Dictionary<string, BuildingInfo>(50);
+            _cachedPresetsBuilding = new ConcurrentDictionary<string, BuildingInfo>(Environment.ProcessorCount, 50);
         }
 
         public bool IsVisible
@@ -190,7 +191,7 @@ namespace AnnoDesigner.ViewModels
                     if (!_cachedPresetsBuilding.TryGetValue(identifierToCheck, out var building))
                     {
                         building = buildingPresets.Buildings.Find(_ => string.Equals(_.Identifier, identifierToCheck, StringComparison.OrdinalIgnoreCase));
-                        _cachedPresetsBuilding.Add(identifierToCheck, building);
+                        _cachedPresetsBuilding.TryAdd(identifierToCheck, building);
                     }
 
                     var isUnknownObject = string.Equals(identifierToCheck, "Unknown Object", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
This PR fixes a crash when exporting the layout as image and selection should be exported.

Also some missing settings are respected when exporting the image (`RenderHarborBlockedArea`, `RenderPanorama`, `RenderTrueInfluenceRange`, `RenderInfluences`).

#### exported image (without selection) on **master**

<details>
  <summary>Click to expand!</summary>

![master_exported](https://user-images.githubusercontent.com/6222752/137479751-bf01ba2d-7065-45a9-8ed6-517d1308b6a0.png)
</details>

#### exported image (_with selection_) on **this PR**

<details>
  <summary>Click to expand!</summary>

![master_new_exported](https://user-images.githubusercontent.com/6222752/137479689-600ddfb2-ee06-483c-869c-87ee3eda4974.png)
</details>

