### PR TITLE
Auto update supports prerelease of app

### DIFF
--- a/AnnoDesigner/Models/IUpdateHelper.cs
+++ b/AnnoDesigner/Models/IUpdateHelper.cs
@@ -14,6 +14,6 @@ namespace AnnoDesigner.Models
 
         Task ReplaceUpdatedPresetsFilesAsync();
 
-        Task<bool> IsNewAppVersionAvailableAsync();
+        Task<(bool, Version)> IsNewAppVersionAvailableAsync();
     }
 }

--- a/AnnoDesigner/Models/ReleaseType.cs
+++ b/AnnoDesigner/Models/ReleaseType.cs
@@ -13,6 +13,7 @@ namespace AnnoDesigner.Models
         PresetsAndIcons,
         PresetsIcons,
         PresetsColors,
-        PresetsWikiBuildingInfo
+        PresetsWikiBuildingInfo,
+        AnnoDesigner
     }
 }

--- a/AnnoDesigner/PreferencesPages/UpdateSettingsPage.xaml
+++ b/AnnoDesigner/PreferencesPages/UpdateSettingsPage.xaml
@@ -29,7 +29,7 @@
                        FontSize="14"
                        Margin="0,10,0,10" />
 
-            <StackPanel Margin="20,0,0,10" Grid.IsSharedSizeScope="True">                
+            <StackPanel Margin="20,0,0,10" Grid.IsSharedSizeScope="True">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="200" SharedSizeGroup="LocalizationColumn" />
@@ -134,6 +134,19 @@
                        Visibility="{Binding IsUpdateAvailable, Converter={StaticResource converterBoolToVisibilityCollapsed}}">
             <Hyperlink Command="{Binding OpenReleasesCommand}">https://github.com/AnnoDesigner/anno-designer/releases</Hyperlink>
             </TextBlock>
+            <Grid Visibility="{Binding IsUpdateAvailable, Converter={StaticResource converterBoolToVisibilityCollapsed}}"
+                  Margin="20,0,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0"
+                           Text="{l:Localize Version, StringFormat='\{0\}:', Mode=OneWay}" />
+                <TextBlock Grid.Column="1"
+                           Margin="10,0,0,0"
+                           Text="{Binding UpdatedVersionValue}" />
+            </Grid>
 
             <TextBlock Text="{l:Localize UpdatePreferencesNoUpdates}"
                        Margin="20,5,0,0"

--- a/AnnoDesigner/UpdateHelper.cs
+++ b/AnnoDesigner/UpdateHelper.cs
@@ -297,7 +297,7 @@ namespace AnnoDesigner
             }
         }
 
-        public async Task<bool> IsNewAppVersionAvailableAsync()
+        public async Task<(bool, Version)> IsNewAppVersionAvailableAsync()
         {
             if (_appSettings.UpdateSupportsPrerelease)
             {
@@ -309,14 +309,14 @@ namespace AnnoDesigner
                 var foundRelease = CheckForAvailableRelease(ReleaseType.AnnoDesigner);
                 if (foundRelease is null)
                 {
-                    return false;
+                    return (false, default);
                 }
 
                 var isNewVersionAvailable = foundRelease.Version > Constants.Version;
 
                 logger.Info($"Found new App version (pre-release): {isNewVersionAvailable} ({Constants.Version} -> {foundRelease.Version})");
 
-                return isNewVersionAvailable;
+                return (isNewVersionAvailable, foundRelease.Version);
             }
             else
             {
@@ -330,7 +330,7 @@ namespace AnnoDesigner
 
                 logger.Info($"Found new App version: {isNewVersionAvailable} ({Constants.Version} -> {parsedVersion})");
 
-                return isNewVersionAvailable;
+                return (isNewVersionAvailable, parsedVersion);
             }
         }
 

--- a/AnnoDesigner/ViewModels/UpdateSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/UpdateSettingsViewModel.cs
@@ -25,6 +25,7 @@ namespace AnnoDesigner.ViewModels
         private bool _automaticUpdateCheck;
         private bool _updateSupportsPrerelease;
         private string _versionValue;
+        private string _updatedVersionValue;
         private string _fileVersionValue;
         private string _presetsVersionValue;
         private string _colorPresetsVersionValue;
@@ -113,8 +114,11 @@ namespace AnnoDesigner.ViewModels
 
         private async Task CheckForNewAppVersionAsync()
         {
-            if (await _updateHelper.IsNewAppVersionAvailableAsync())
+            (bool isNewAppVersionAvailable, Version newAppVersion) = await _updateHelper.IsNewAppVersionAvailableAsync();
+
+            if (isNewAppVersionAvailable)
             {
+                UpdatedVersionValue = newAppVersion.ToString();
                 IsUpdateAvailable = true;
                 _messageBoxService.ShowMessage(Application.Current.MainWindow,
                     _localizationHelper.GetLocalization("UpdatePreferencesNewAppUpdateAvailable") + Environment.NewLine + Environment.NewLine + "https://github.com/AnnoDesigner/anno-designer/releases/",
@@ -299,6 +303,12 @@ namespace AnnoDesigner.ViewModels
         {
             get { return _treeLocalizationVersionValue; }
             set { UpdateProperty(ref _treeLocalizationVersionValue, value); }
+        }
+
+        public string UpdatedVersionValue
+        {
+            get { return _updatedVersionValue; }
+            set { UpdateProperty(ref _updatedVersionValue, value); }
         }
     }
 }


### PR DESCRIPTION
This PR kind of fixes the `UpdateHelper` to also check for pre-releases of the app, if the corresponding setting is checked.
The check for pre-releases of presets was already present and working.

Also the new version is displayed inside the preferences window.

![pre-release](https://user-images.githubusercontent.com/6222752/144614799-0b3e13ad-9960-4b36-885c-6f872442bab0.png)