### PR TITLE
Fix wrong location of log file

### DIFF
--- a/AnnoDesigner.Core/AnnoDesigner.Core.csproj
+++ b/AnnoDesigner.Core/AnnoDesigner.Core.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.7.8" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.25" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NLog" />
+    <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 </Project>

--- a/AnnoDesigner/AnnoDesigner.csproj
+++ b/AnnoDesigner/AnnoDesigner.csproj
@@ -85,10 +85,10 @@
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.8.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
-    <PackageReference Include="NLog" Version="4.7.8" />
+    <PackageReference Include="NLog" />
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.25" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.25" />
+    <PackageReference Include="System.IO.Abstractions" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="echo create directory for icons &quot;$(TargetDir)icons&quot;&#xD;&#xA;if not exist &quot;$(TargetDir)icons&quot; md &quot;$(TargetDir)icons&quot;&#xD;&#xA;&#xD;&#xA;rem ROBOCOPY exits with &quot;success codes&quot; which are under 8. See: http://support.microsoft.com/kb/954404&#xD;&#xA;rem This means that:&#xD;&#xA;&#xD;&#xA;rem robocopy exit code 0 = no files copied&#xD;&#xA;rem robocopy exit code 1 = files copied&#xD;&#xA;rem When the result is 1, this becomes an error exit code in visual studio.&#xD;&#xA;&#xD;&#xA;echo copy icons from &quot;$(ProjectDir)\icons&quot; to &quot;$(TargetDir)icons&quot;&#xD;&#xA;ROBOCOPY &quot;$(ProjectDir)\icons&quot; &quot;$(TargetDir)icons&quot; *.* /E /NFL /NDL /NJH /NJS /nc /ns /np&#xD;&#xA;&#xD;&#xA;if %2525ERRORLEVEL%2525 GEQ 8 goto failed&#xD;&#xA;&#xD;&#xA;rem end of batch&#xD;&#xA;goto success&#xD;&#xA;&#xD;&#xA;:failed&#xD;&#xA;exit -1&#xD;&#xA;&#xD;&#xA;:success&#xD;&#xA;exit 0" />

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -169,8 +169,8 @@
         Off
         -->
 
-        <variable name="logDirectory" value="logs" />
-        <variable name="archiveDirectory" value="${logDirectory}//archive" />
+        <variable name="logDirectory" value="${basedir:processDir=true}/logs" />
+        <variable name="archiveDirectory" value="${logDirectory}/archive" />
         <variable name="logFileName" value="Logfile_AnnoDesigner" />
         <targets async="false">
             <!--

--- a/ColorPresetsDesigner/App.config
+++ b/ColorPresetsDesigner/App.config
@@ -41,8 +41,8 @@
         Off
         -->
 
-        <variable name="logDirectory" value="logs" />
-        <variable name="archiveDirectory" value="${logDirectory}//archive" />
+        <variable name="logDirectory" value="${basedir:processDir=true}/logs" />
+        <variable name="archiveDirectory" value="${logDirectory}/archive" />
         <variable name="logFileName" value="Logfile_ColorPresetsDesigner" />
         <targets async="false">
             <!--

--- a/ColorPresetsDesigner/ColorPresetsDesigner.csproj
+++ b/ColorPresetsDesigner/ColorPresetsDesigner.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.8.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
-    <PackageReference Include="NLog" Version="4.7.8" />
+    <PackageReference Include="NLog" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="WindowsAPICodePack-Core" Version="1.1.2" />
     <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,36 @@
+<Project>
+  <PropertyGroup Label="Versions">
+    <!-- versionnumbers as variables to be used in pre- and postbuild events -->
+    <NLogVersion>4.7.13</NLogVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <IOAbstractionsVersion>14.0.3</IOAbstractionsVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Documentation">
+    <!--<GenerateDocumentationFile Condition="'$(Configuration)' == 'Debug'">true</GenerateDocumentationFile>-->
+    <DocumentationFile Condition="'$(Configuration)' == 'Debug'">$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <!--
+      Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+      not report warnings for missing comments.
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'member' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      CS1712: Type parameter 'parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)
+    -->
+    <NoWarn Condition="'$(Language)' == 'C#'">$(NoWarn),1573,1591,1712</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup Label="IO Abstraction">
+    <PackageReference Update="System.IO.Abstractions" Version="$(IOAbstractionsVersion)" />
+    <PackageReference Update="System.IO.Abstractions.TestingHelpers" Version="$(IOAbstractionsVersion)" />
+    <PackageReference Include="Roslyn.System.IO.Abstractions.Analyzers" Version="12.2.19">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="NLog" Version="$(NLogVersion)" />
+    <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/FandomParser/FandomParser.Core/FandomParser.Core.csproj
+++ b/FandomParser/FandomParser.Core/FandomParser.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/FandomParser/FandomParser/App.config
+++ b/FandomParser/FandomParser/App.config
@@ -25,8 +25,8 @@
         Off
         -->
 
-        <variable name="logDirectory" value="logs" />
-        <variable name="archiveDirectory" value="${logDirectory}//archive" />
+        <variable name="logDirectory" value="${basedir:processDir=true}/logs" />
+        <variable name="archiveDirectory" value="${logDirectory}/archive" />
         <variable name="logFileName" value="Logfile_FandomParser" />
         <targets async="false">
             <!--

--- a/FandomParser/FandomParser/FandomParser.csproj
+++ b/FandomParser/FandomParser/FandomParser.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CXuesong.MW.WikiClientLibrary" Version="0.7.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="NLog" Version="4.7.2" />
+    <PackageReference Include="NLog" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/FandomParser/InfoboxParser/InfoboxParser.csproj
+++ b/FandomParser/InfoboxParser/InfoboxParser.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.2" />
+    <PackageReference Include="NLog" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FandomTemplateExporter/FandomTemplateExporter/App.config
+++ b/FandomTemplateExporter/FandomTemplateExporter/App.config
@@ -44,8 +44,8 @@
         Off
         -->
 
-        <variable name="logDirectory" value="logs" />
-        <variable name="archiveDirectory" value="${logDirectory}//archive" />
+        <variable name="logDirectory" value="${basedir:processDir=true}/logs" />
+        <variable name="archiveDirectory" value="${logDirectory}/archive" />
         <variable name="logFileName" value="Logfile_FandomTemplateExporter" />
         <targets async="false">
             <!--

--- a/FandomTemplateExporter/FandomTemplateExporter/FandomTemplateExporter.csproj
+++ b/FandomTemplateExporter/FandomTemplateExporter/FandomTemplateExporter.csproj
@@ -32,9 +32,7 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.1.19</Version>
     </PackageReference>
-    <PackageReference Include="NLog">
-      <Version>4.7.1</Version>
-    </PackageReference>
+    <PackageReference Include="NLog" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="WindowsAPICodePack-Core">
       <Version>1.1.2</Version>

--- a/PresetParser/PresetParser.csproj
+++ b/PresetParser/PresetParser.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\AnnoDesigner.Core\AnnoDesigner.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.25" />
+    <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
   <PropertyGroup />
 </Project>

--- a/Tests/AnnoDesigner.Core.Tests/AnnoDesigner.Core.Tests.csproj
+++ b/Tests/AnnoDesigner.Core.Tests/AnnoDesigner.Core.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.25" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.console">

--- a/Tests/AnnoDesigner.Tests/AnnoDesigner.Tests.csproj
+++ b/Tests/AnnoDesigner.Tests/AnnoDesigner.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.25" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.console">

--- a/Tests/PresetParser.Tests/PresetParser.Tests.csproj
+++ b/Tests/PresetParser.Tests/PresetParser.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.25" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.console">


### PR DESCRIPTION
This PR fixes #387.
Also the dependencies were updated and the version numbers of those dependencies is now at a central location (`Directory.Build.targets`).