### PR TITLE
Use Windows clipboard instead of custom logic for clipboard

### DIFF
--- a/AnnoDesigner.Core/CoreConstants.cs
+++ b/AnnoDesigner.Core/CoreConstants.cs
@@ -29,7 +29,7 @@ namespace AnnoDesigner.Core
         /// <summary>
         /// Clipboard format used to serialize list of <see cref="Models.AnnoObject"/>.
         /// </summary>
-        internal const string AnnoDesignerClipboardFormat = "AnnoDesignerLayout";
+        public const string AnnoDesignerClipboardFormat = "AnnoDesignerLayout";
 
         public static class PresetsFiles
         {

--- a/AnnoDesigner.Core/CoreConstants.cs
+++ b/AnnoDesigner.Core/CoreConstants.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AnnoDesigner.Core
 {
@@ -29,6 +25,11 @@ namespace AnnoDesigner.Core
         /// Prefix for temporary updated presets file.
         /// </summary>
         public const string PrefixUpdatedPresetsFile = "temp_";
+
+        /// <summary>
+        /// Clipboard format used to serialize list of <see cref="Models.AnnoObject"/>.
+        /// </summary>
+        internal const string AnnoDesignerClipboardFormat = "AnnoDesignerLayout";
 
         public static class PresetsFiles
         {

--- a/AnnoDesigner.Core/Layout/Models/LayoutFile.cs
+++ b/AnnoDesigner.Core/Layout/Models/LayoutFile.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using AnnoDesigner.Core.Models;
 
@@ -13,12 +14,12 @@ namespace AnnoDesigner.Core.Layout.Models
         [DataMember(Order = 99)]
         public List<AnnoObject> Objects { get; set; }
 
-        public LayoutFile() : this(null) { }
+        public LayoutFile() { }
 
-        public LayoutFile(List<AnnoObject> objects)
+        public LayoutFile(IEnumerable<AnnoObject> objects)
         {
             FileVersion = CoreConstants.LayoutFileVersion;
-            Objects = objects;
+            Objects = objects.ToList();
         }
     }
 }

--- a/AnnoDesigner.Core/Models/IClipboard.cs
+++ b/AnnoDesigner.Core/Models/IClipboard.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+
+namespace AnnoDesigner.Core.Models
+{
+    public interface IClipboard
+    {
+        /// <summary>
+        /// Clears any data from the Clipboard.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
+        /// Queries the Clipboard for the presence of data in a specified data format.
+        /// </summary>
+        /// <param name="format">The format of the data to look for.</param>
+        /// <returns><c>true</c> if the Clipboard contains data in the specified <paramref name="format"/>, otherwise <c>false</c>.</returns>
+        /// <exception cref="System.ArgumentNullException"><paramref name="format"/> is <c>null</c></exception>
+        bool ContainsData(string format);
+
+        /// <summary>
+        /// Returns a list of strings that contains a list of dropped files available on the Clipboard.
+        /// </summary>
+        /// <returns>A list of strings, where each string specifies the name of a file in the list of dropped files on the Clipboard, or <c>null</c> if the data is unavailable in this format.</returns>
+        IReadOnlyList<string> GetFileDropList();
+
+        /// <summary>
+        /// Stores the specified data on the Clipboard in the specified format.
+        /// </summary>
+        /// <param name="format">A string that specifies the format to use to store the data.</param>
+        /// <param name="data">An object representing the data to store on the Clipboard.</param>
+        void SetData(string format, object data);
+
+        /// <summary>
+        /// Retrieves data in a specified format from the Clipboard.
+        /// </summary>
+        /// <param name="format">A string that specifies the format of the data to retrieve.</param>
+        /// <returns>An object that contains the data in the specified <paramref name="format"/>, or <c>null</c> if the data is unavailable in the specified <paramref name="format"/>.</returns>
+        /// <exception cref="System.ArgumentNullException"><paramref name="format"/> is <c>null</c></exception>
+        object GetData(string format);
+
+        /// <summary>
+        /// Permanently adds the data that is on the Clipboard so that it is available after the data's original application closes.
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// Queries the Clipboard for the presence of data in text format.
+        /// </summary>
+        /// <returns><c>true</c> if the Clipboard contains data in the text format, otherwise <c>false</c>.</returns>
+        bool ContainsText();
+
+        /// <summary>
+        /// Returns a string containing the text data on the Clipboard.
+        /// </summary>
+        /// <returns>A string containing the text data, or an empty string if no text data is available on the Clipboard.</returns>
+        string GetText();
+    }
+}

--- a/AnnoDesigner.Core/Models/WindowsClipboard.cs
+++ b/AnnoDesigner.Core/Models/WindowsClipboard.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+
+namespace AnnoDesigner.Core.Models
+{
+    public class WindowsClipboard : IClipboard
+    {
+        public void Clear()
+        {
+            Clipboard.Clear();
+        }
+
+        public bool ContainsData(string format)
+        {
+            return Clipboard.ContainsData(format);
+        }
+
+        public bool ContainsText()
+        {
+            return Clipboard.ContainsText();
+        }
+
+        public void Flush()
+        {
+            Clipboard.Flush();
+        }
+
+        public object GetData(string format)
+        {
+            return Clipboard.GetData(format);
+        }
+
+        public IReadOnlyList<string> GetFileDropList()
+        {
+            var clipboardData = Clipboard.GetFileDropList();
+            if (clipboardData is null)
+            {
+                return null;
+            }
+
+            return new ReadOnlyCollection<string>(clipboardData.Cast<string>().ToList());
+        }
+
+        public string GetText()
+        {
+            return Clipboard.GetText();
+        }
+
+        public void SetData(string format, object data)
+        {
+            Clipboard.SetData(format, data);
+        }
+    }
+}

--- a/AnnoDesigner.Core/Services/ClipboardService.cs
+++ b/AnnoDesigner.Core/Services/ClipboardService.cs
@@ -20,12 +20,14 @@ namespace AnnoDesigner.Core.Services
 
         public void Copy(IEnumerable<AnnoObject> objects)
         {
-            if (!objects.Any())
+            if (objects.Any())
             {
                 using var memoryStream = new MemoryStream();
                 _layoutLoader.SaveLayout(new LayoutFile(objects), memoryStream);
                 memoryStream.Seek(0, SeekOrigin.Begin);
+                Clipboard.Clear();
                 Clipboard.SetData(CoreConstants.AnnoDesignerClipboardFormat, memoryStream);
+                Clipboard.Flush();
             }
         }
 

--- a/AnnoDesigner.Core/Services/ClipboardService.cs
+++ b/AnnoDesigner.Core/Services/ClipboardService.cs
@@ -46,10 +46,13 @@ namespace AnnoDesigner.Core.Services
 
             if (_clipboard.ContainsData(CoreConstants.AnnoDesignerClipboardFormat))
             {
-                var stream = _clipboard.GetData(CoreConstants.AnnoDesignerClipboardFormat) as Stream;
                 try
                 {
-                    return _layoutLoader.LoadLayout(stream, forceLoad: true).Objects;
+                    var stream = _clipboard.GetData(CoreConstants.AnnoDesignerClipboardFormat) as Stream;
+                    if (stream is not null)
+                    {
+                        return _layoutLoader.LoadLayout(stream, forceLoad: true).Objects;
+                    }
                 }
                 catch (JsonReaderException) { }
             }

--- a/AnnoDesigner.Core/Services/ClipboardService.cs
+++ b/AnnoDesigner.Core/Services/ClipboardService.cs
@@ -8,16 +8,9 @@ using AnnoDesigner.Core.Layout.Models;
 using AnnoDesigner.Core.Models;
 using Newtonsoft.Json;
 
-namespace AnnoDesigner
+namespace AnnoDesigner.Core.Services
 {
-    public interface IClipboardManager
-    {
-        void Copy(IEnumerable<AnnoObject> objects);
-
-        ICollection<AnnoObject> Paste();
-    }
-
-    public class ClipboardManager : IClipboardManager
+    public class ClipboardService : IClipboardService
     {
         public void Copy(IEnumerable<AnnoObject> objects)
         {
@@ -26,7 +19,7 @@ namespace AnnoDesigner
                 using var memoryStream = new MemoryStream();
                 new LayoutLoader().SaveLayout(new LayoutFile(objects), memoryStream);
                 memoryStream.Seek(0, SeekOrigin.Begin);
-                Clipboard.SetData(Constants.AnnoDesignerClipboardFormat, memoryStream);
+                Clipboard.SetData(CoreConstants.AnnoDesignerClipboardFormat, memoryStream);
             }
         }
 
@@ -43,15 +36,17 @@ namespace AnnoDesigner
                 }
                 catch (JsonReaderException) { }
             }
-            if (Clipboard.ContainsData(Constants.AnnoDesignerClipboardFormat))
+
+            if (Clipboard.ContainsData(CoreConstants.AnnoDesignerClipboardFormat))
             {
-                var stream = Clipboard.GetData(Constants.AnnoDesignerClipboardFormat) as Stream;
+                var stream = Clipboard.GetData(CoreConstants.AnnoDesignerClipboardFormat) as Stream;
                 try
                 {
                     return loader.LoadLayout(stream, true).Objects;
                 }
                 catch (JsonReaderException) { }
             }
+
             if (Clipboard.ContainsText())
             {
                 using var memoryStream = new MemoryStream();

--- a/AnnoDesigner.Core/Services/ClipboardService.cs
+++ b/AnnoDesigner.Core/Services/ClipboardService.cs
@@ -21,7 +21,7 @@ namespace AnnoDesigner.Core.Services
 
         public void Copy(IEnumerable<AnnoObject> objects)
         {
-            if (objects.Any())
+            if (objects is not null && objects.Any())
             {
                 using var memoryStream = new MemoryStream();
                 _layoutLoader.SaveLayout(new LayoutFile(objects), memoryStream);

--- a/AnnoDesigner.Core/Services/IClipboardService.cs
+++ b/AnnoDesigner.Core/Services/IClipboardService.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using AnnoDesigner.Core.Models;
+
+namespace AnnoDesigner.Core.Services
+{
+    public interface IClipboardService
+    {
+        void Copy(IEnumerable<AnnoObject> objects);
+
+        ICollection<AnnoObject> Paste();
+    }
+}

--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -32,7 +32,6 @@ using AnnoDesigner.Services;
 using AnnoDesigner.Undo;
 using AnnoDesigner.Undo.Operations;
 using Microsoft.Win32;
-using Newtonsoft.Json;
 using NLog;
 
 namespace AnnoDesigner

--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -590,7 +590,8 @@ namespace AnnoDesigner
             _localizationHelper = localizationHelperToUse ?? Localization.Localization.Instance;
             _layoutLoader = new LayoutLoader();
             UndoManager = undoManager ?? new UndoManager();
-            ClipboardService = clipboardService ?? new ClipboardService(_layoutLoader);
+            IClipboard clipboard = new WindowsClipboard();
+            ClipboardService = clipboardService ?? new ClipboardService(_layoutLoader, clipboard);
 
             _showScrollBars = _appSettings.ShowScrollbars;
             _hideInfluenceOnSelection = _appSettings.HideInfluenceOnSelection;

--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -67,7 +67,7 @@ namespace AnnoDesigner
 
         public IUndoManager UndoManager { get; private set; }
 
-        public IClipboardManager ClipboardManager { get; set; }
+        public IClipboardService ClipboardService { get; set; }
 
         /// <summary>
         /// Contains all loaded icons as a mapping of name (the filename without extension) to loaded BitmapImage.
@@ -577,7 +577,7 @@ namespace AnnoDesigner
             IMessageBoxService messageBoxServiceToUse = null,
             ILocalizationHelper localizationHelperToUse = null,
             IUndoManager undoManager = null,
-            IClipboardManager clipboardManager = null)
+            IClipboardService clipboardService = null)
         {
             InitializeComponent();
 
@@ -589,7 +589,7 @@ namespace AnnoDesigner
             _messageBoxService = messageBoxServiceToUse ?? new MessageBoxService();
             _localizationHelper = localizationHelperToUse ?? Localization.Localization.Instance;
             UndoManager = undoManager ?? new UndoManager();
-            ClipboardManager = clipboardManager ?? new ClipboardManager();
+            ClipboardService = clipboardService ?? new ClipboardService();
 
             _layoutLoader = new LayoutLoader();
 
@@ -2916,7 +2916,7 @@ namespace AnnoDesigner
         {
             if (SelectedObjects.Count != 0)
             {
-                ClipboardManager.Copy(SelectedObjects.Select(x => x.WrappedAnnoObject));
+                ClipboardService.Copy(SelectedObjects.Select(x => x.WrappedAnnoObject));
 
                 var localizedMessage = SelectedObjects.Count == 1 ? _localizationHelper.GetLocalization("ItemCopied") : _localizationHelper.GetLocalization("ItemsCopied");
                 StatusMessage = $"{SelectedObjects.Count} {localizedMessage}";
@@ -2927,7 +2927,7 @@ namespace AnnoDesigner
         private readonly ICommand pasteCommand;
         private void ExecutePaste(object param)
         {
-            var objects = ClipboardManager.Paste();
+            var objects = ClipboardService.Paste();
             if (objects.Count > 0)
             {
                 CurrentObjects = objects.Select(x => new LayoutObject(x, _coordinateHelper, _brushCache, _penCache)).ToList();

--- a/AnnoDesigner/AnnoCanvas.xaml.cs
+++ b/AnnoDesigner/AnnoCanvas.xaml.cs
@@ -588,10 +588,9 @@ namespace AnnoDesigner
             _penCache = penCacheToUse ?? new PenCache();
             _messageBoxService = messageBoxServiceToUse ?? new MessageBoxService();
             _localizationHelper = localizationHelperToUse ?? Localization.Localization.Instance;
-            UndoManager = undoManager ?? new UndoManager();
-            ClipboardService = clipboardService ?? new ClipboardService();
-
             _layoutLoader = new LayoutLoader();
+            UndoManager = undoManager ?? new UndoManager();
+            ClipboardService = clipboardService ?? new ClipboardService(_layoutLoader);
 
             _showScrollBars = _appSettings.ShowScrollbars;
             _hideInfluenceOnSelection = _appSettings.HideInfluenceOnSelection;

--- a/AnnoDesigner/ClipboardManager.cs
+++ b/AnnoDesigner/ClipboardManager.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using AnnoDesigner.Core.Layout;
+using AnnoDesigner.Core.Layout.Models;
+using AnnoDesigner.Core.Models;
+using Newtonsoft.Json;
+
+namespace AnnoDesigner
+{
+    public interface IClipboardManager
+    {
+        void Copy(IEnumerable<AnnoObject> objects);
+
+        ICollection<AnnoObject> Paste();
+    }
+
+    public class ClipboardManager : IClipboardManager
+    {
+        public void Copy(IEnumerable<AnnoObject> objects)
+        {
+            if (!objects.Any())
+            {
+                using var memoryStream = new MemoryStream();
+                new LayoutLoader().SaveLayout(new LayoutFile(objects), memoryStream);
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                Clipboard.SetData(Constants.AnnoDesignerClipboardFormat, memoryStream);
+            }
+        }
+
+        public ICollection<AnnoObject> Paste()
+        {
+            var loader = new LayoutLoader();
+
+            var files = Clipboard.GetFileDropList();
+            if (files.Count == 1)
+            {
+                try
+                {
+                    return loader.LoadLayout(files[0], true).Objects;
+                }
+                catch (JsonReaderException) { }
+            }
+            if (Clipboard.ContainsData(Constants.AnnoDesignerClipboardFormat))
+            {
+                var stream = Clipboard.GetData(Constants.AnnoDesignerClipboardFormat) as Stream;
+                try
+                {
+                    return loader.LoadLayout(stream, true).Objects;
+                }
+                catch (JsonReaderException) { }
+            }
+            if (Clipboard.ContainsText())
+            {
+                using var memoryStream = new MemoryStream();
+                using var streamWriter = new StreamWriter(memoryStream);
+                streamWriter.Write(Clipboard.GetText());
+                streamWriter.Flush();
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                try
+                {
+                    return loader.LoadLayout(memoryStream, true).Objects;
+                }
+                catch (JsonReaderException) { }
+            }
+
+            return Array.Empty<AnnoObject>();
+        }
+    }
+}

--- a/AnnoDesigner/Constants.cs
+++ b/AnnoDesigner/Constants.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Media.Imaging;
+using AnnoDesigner.Core.Models;
 
 namespace AnnoDesigner
 {
@@ -107,5 +108,10 @@ namespace AnnoDesigner
         /// The default number of recent files to show.
         /// </summary>
         public const int MaxRecentFiles = 10;
+
+        /// <summary>
+        /// Clipboard format used to serialize list of <see cref="AnnoObject"/>.
+        /// </summary>
+        public const string AnnoDesignerClipboardFormat = "AnnoDesignerLayout";
     }
 }

--- a/AnnoDesigner/Constants.cs
+++ b/AnnoDesigner/Constants.cs
@@ -108,10 +108,5 @@ namespace AnnoDesigner
         /// The default number of recent files to show.
         /// </summary>
         public const int MaxRecentFiles = 10;
-
-        /// <summary>
-        /// Clipboard format used to serialize list of <see cref="AnnoObject"/>.
-        /// </summary>
-        public const string AnnoDesignerClipboardFormat = "AnnoDesignerLayout";
     }
 }

--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -752,9 +752,6 @@
                 <StatusBarItem Content="{l:Localize StatusBarControls}" />
                 <StatusBarItem Content="{Binding StatusMessage}"
                                Margin="10,0,0,0" />
-                <StatusBarItem Content="{Binding StatusMessageClipboard}"
-                               Margin="10,0,0,0"
-                               HorizontalAlignment="Right" />
             </StatusBar>
         </Grid>
     </xctk:BusyIndicator>

--- a/AnnoDesigner/Models/IAnnoCanvas.cs
+++ b/AnnoDesigner/Models/IAnnoCanvas.cs
@@ -15,7 +15,6 @@ namespace AnnoDesigner.Models
     public interface IAnnoCanvas : IHotkeySource
     {
         event EventHandler<EventArgs> ColorsInLayoutUpdated;
-        event Action<List<LayoutObject>> OnClipboardChanged;
         event EventHandler<UpdateStatisticsEventArgs> StatisticsUpdated;
         event EventHandler<FileLoadedEventArgs> OnLoadedFileChanged;
         event Action<string> OnStatusMessageChanged;
@@ -25,7 +24,6 @@ namespace AnnoDesigner.Models
 
         QuadTree<LayoutObject> PlacedObjects { get; set; }
         HashSet<LayoutObject> SelectedObjects { get; set; }
-        List<LayoutObject> ClipboardObjects { get; }
         BuildingPresets BuildingPresets { get; }
         Dictionary<string, IconImage> Icons { get; }
         IUndoManager UndoManager { get; }

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -71,7 +71,6 @@ namespace AnnoDesigner.ViewModels
         private bool _isLanguageChange;
         private bool _isBusy;
         private string _statusMessage;
-        private string _statusMessageClipboard;
         private ObservableCollection<SupportedLanguage> _languages;
         private ObservableCollection<IconImage> _availableIcons;
         private IconImage _selectedIcon;
@@ -247,12 +246,6 @@ namespace AnnoDesigner.ViewModels
                 RepopulateTreeView();
 
                 BuildingSettingsViewModel.UpdateLanguageBuildingInfluenceType();
-
-                //Force a language update on the clipboard status item.
-                if (!string.IsNullOrWhiteSpace(StatusMessageClipboard))
-                {
-                    AnnoCanvas_ClipboardChanged(AnnoCanvas.ClipboardObjects);
-                }
 
                 //update settings
                 _appSettings.SelectedLanguage = _commons.CurrentLanguage;
@@ -520,11 +513,6 @@ namespace AnnoDesigner.ViewModels
         private void AnnoCanvas_StatisticsUpdated(object sender, UpdateStatisticsEventArgs e)
         {
             _ = UpdateStatisticsAsync(e.Mode);
-        }
-
-        private void AnnoCanvas_ClipboardChanged(List<LayoutObject> itemsOnClipboard)
-        {
-            StatusMessageClipboard = _localizationHelper.GetLocalization("StatusBarItemsOnClipboard") + ": " + itemsOnClipboard.Count;
         }
 
         private void AnnoCanvas_StatusMessageChanged(string message)
@@ -802,7 +790,7 @@ namespace AnnoDesigner.ViewModels
             try
             {
                 AnnoCanvas.Normalize(1);
-                var layoutToSave = new LayoutFile(AnnoCanvas.PlacedObjects.Select(x => x.WrappedAnnoObject).ToList());
+                var layoutToSave = new LayoutFile(AnnoCanvas.PlacedObjects.Select(x => x.WrappedAnnoObject));
                 layoutToSave.LayoutVersion = LayoutSettingsViewModel.LayoutVersion;
                 _layoutLoader.SaveLayout(layoutToSave, filePath);
                 AnnoCanvas.UndoManager.IsDirty = false;
@@ -836,7 +824,6 @@ namespace AnnoDesigner.ViewModels
 
                 _annoCanvas = value;
                 _annoCanvas.StatisticsUpdated += AnnoCanvas_StatisticsUpdated;
-                _annoCanvas.OnClipboardChanged += AnnoCanvas_ClipboardChanged;
                 _annoCanvas.OnCurrentObjectChanged += UpdateUIFromObject;
                 _annoCanvas.OnStatusMessageChanged += AnnoCanvas_StatusMessageChanged;
                 _annoCanvas.OnLoadedFileChanged += AnnoCanvas_LoadedFileChanged;
@@ -973,12 +960,6 @@ namespace AnnoDesigner.ViewModels
         {
             get { return _statusMessage; }
             set { UpdateProperty(ref _statusMessage, value); }
-        }
-
-        public string StatusMessageClipboard
-        {
-            get { return _statusMessageClipboard; }
-            set { UpdateProperty(ref _statusMessageClipboard, value); }
         }
 
         public ObservableCollection<SupportedLanguage> Languages
@@ -1459,7 +1440,7 @@ namespace AnnoDesigner.ViewModels
                 using (var ms = new MemoryStream())
                 {
                     AnnoCanvas.Normalize(1);
-                    var layoutToSave = new LayoutFile(AnnoCanvas.PlacedObjects.Select(x => x.WrappedAnnoObject).ToList());
+                    var layoutToSave = new LayoutFile(AnnoCanvas.PlacedObjects.Select(x => x.WrappedAnnoObject));
                     _layoutLoader.SaveLayout(layoutToSave, ms);
 
                     var jsonString = Encoding.UTF8.GetString(ms.ToArray());

--- a/Tests/AnnoDesigner.Core.Tests/ClipboardServiceTests.cs
+++ b/Tests/AnnoDesigner.Core.Tests/ClipboardServiceTests.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AnnoDesigner.Core.Layout;
+using AnnoDesigner.Core.Layout.Models;
+using AnnoDesigner.Core.Models;
+using AnnoDesigner.Core.Services;
+using AnnoDesigner.Core.Tests.Mocks;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace AnnoDesigner.Core.Tests
+{
+    public class ClipboardServiceTests
+    {
+        private readonly MockedClipboard _mockedClipboard;
+        private readonly ILayoutLoader _mockedLayoutLoader;
+
+        public ClipboardServiceTests()
+        {
+            _mockedClipboard = new MockedClipboard();
+            _mockedLayoutLoader = new LayoutLoader();
+        }
+
+        private IClipboardService GetService(ILayoutLoader layoutLoaderToUse = null,
+            IClipboard clipboardToUse = null)
+        {
+            return new ClipboardService(layoutLoaderToUse ?? _mockedLayoutLoader,
+                clipboardToUse ?? _mockedClipboard);
+        }
+
+        private List<AnnoObject> GetListOfObjects()
+        {
+            return new List<AnnoObject>
+            {
+                new AnnoObject
+                {
+                    Identifier = "my dummy"
+                }
+            };
+        }
+
+        #region Copy tests
+
+        [Fact]
+        public void Copy_ListIsEmpty_ShouldNotAddDataToClipboard()
+        {
+            // Arrange
+            var service = GetService();
+
+            // Act
+            service.Copy(Array.Empty<AnnoObject>());
+
+            // Assert
+            Assert.Null(_mockedClipboard.GetData(CoreConstants.AnnoDesignerClipboardFormat));
+        }
+
+        [Fact]
+        public void Copy_ListIsNull_ShouldNotThrowAndNotAddDataToClipboard()
+        {
+            // Arrange
+            var service = GetService();
+
+            // Act
+            var ex = Record.Exception(() => service.Copy(null));
+
+            // Assert
+            Assert.Null(ex);
+            Assert.Null(_mockedClipboard.GetData(CoreConstants.AnnoDesignerClipboardFormat));
+        }
+
+        [Fact]
+        public void Copy_ListHasData_ShouldAddDataToClipboard()
+        {
+            // Arrange
+            var service = GetService();
+            var data = GetListOfObjects();
+
+            // Act
+            service.Copy(data);
+
+            // Assert
+            var clipboardStream = _mockedClipboard.GetData(CoreConstants.AnnoDesignerClipboardFormat) as System.IO.Stream;
+            var copiedObjects = _mockedLayoutLoader.LoadLayout(clipboardStream, forceLoad: true).Objects;
+
+            Assert.Equal(data.Count, copiedObjects.Count);
+            Assert.All(data, x =>
+            {
+                //Assert.Contains(x, copiedObjects); //not useable because of missing cutom comparer for AnnoObject
+                Assert.Contains(copiedObjects, y => y.Identifier.Equals(x.Identifier, StringComparison.OrdinalIgnoreCase));
+            });
+        }
+
+        [Fact]
+        public void Copy_ListHasData_ShouldClearClipboardBeforeAddingData()
+        {
+            // Arrange
+            var mockedClipboard = new Mock<IClipboard>();
+            var callOrder = 0;
+            _ = mockedClipboard.Setup(x => x.Clear()).Callback(() => Assert.Equal(0, callOrder++));
+            _ = mockedClipboard.Setup(x => x.SetData(It.IsAny<string>(), It.IsAny<object>())).Callback(() => Assert.Equal(1, callOrder++));
+
+            var service = GetService(clipboardToUse: mockedClipboard.Object);
+            var data = GetListOfObjects();
+
+            // Act
+            service.Copy(data);
+
+            // Assert
+            mockedClipboard.Verify(x => x.Clear(), Times.Once);
+        }
+
+        [Fact]
+        public void Copy_ListHasData_ShouldFlushClipboardAfterAddingData()
+        {
+            // Arrange
+            var mockedClipboard = new Mock<IClipboard>();
+            var callOrder = 0;
+            _ = mockedClipboard.Setup(x => x.SetData(It.IsAny<string>(), It.IsAny<object>())).Callback(() => Assert.Equal(0, callOrder++));
+            _ = mockedClipboard.Setup(x => x.Flush()).Callback(() => Assert.Equal(1, callOrder++));
+
+            var service = GetService(clipboardToUse: mockedClipboard.Object);
+            var data = GetListOfObjects();
+
+            // Act
+            service.Copy(data);
+
+            // Assert
+            mockedClipboard.Verify(x => x.Flush(), Times.Once);
+        }
+
+        #endregion
+
+        #region Paste tests
+
+        [Fact]
+        public void Paste_ClipboardHasNoData_ShouldReturnEmpty()
+        {
+            // Arrange
+            var service = GetService();
+
+            // Act
+            var result = service.Paste();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Paste_Files_ClipboardHasMultipleFiles_ShouldReturnEmpty()
+        {
+            // Arrange
+            var service = GetService();
+            _mockedClipboard.AddFilesToClipboard(new List<string> { "first file path", "second file path" });
+
+            // Act
+            var result = service.Paste();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Paste_Files_ClipboardFileListReturnsNull_ShouldReturnEmpty()
+        {
+            // Arrange
+            var mockedClipboard = new Mock<IClipboard>();
+            _ = mockedClipboard.Setup(x => x.GetFileDropList()).Returns(() => null);
+
+            var service = GetService(clipboardToUse: mockedClipboard.Object);
+
+            // Act
+            var result = service.Paste();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Paste_Files_ClipboardHasSingleFile_ShouldReturnLayoutObjects()
+        {
+            // Arrange
+            var data = GetListOfObjects();
+
+            var mockedLayoutLoader = new Mock<ILayoutLoader>();
+            _ = mockedLayoutLoader.Setup(x => x.LoadLayout(It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(() => new LayoutFile(data));
+
+            var service = GetService(layoutLoaderToUse: mockedLayoutLoader.Object);
+            _mockedClipboard.AddFilesToClipboard(new List<string> { "first" });
+
+            // Act
+            var result = service.Paste();
+
+            // Assert
+            Assert.Equal(data, result);
+        }
+
+        [Fact]
+        public void Paste_Files_ClipboardHasOnlySingleFileAndLayoutLoaderThrows_ShouldReturnEmpty()
+        {
+            // Arrange
+            var data = GetListOfObjects();
+
+            var mockedLayoutLoader = new Mock<ILayoutLoader>();
+            _ = mockedLayoutLoader.Setup(x => x.LoadLayout(It.IsAny<string>(), It.IsAny<bool>()))
+                .Throws(new JsonReaderException());
+
+            var service = GetService(layoutLoaderToUse: mockedLayoutLoader.Object);
+            _mockedClipboard.AddFilesToClipboard(new List<string> { "first" });
+
+            // Act
+            var result = service.Paste();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/AnnoDesigner.Core.Tests/Mocks/MockedClipboard.cs
+++ b/Tests/AnnoDesigner.Core.Tests/Mocks/MockedClipboard.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using AnnoDesigner.Core.Models;
+
+namespace AnnoDesigner.Core.Tests.Mocks
+{
+    public class MockedClipboard : IClipboard
+    {
+        private List<string> _files = new List<string>();
+        private Dictionary<string, object> _data = new Dictionary<string, object>();
+        private string _text;
+
+        public void AddFilesToClipboard(List<string> filesToAdd)
+        {
+            _files.AddRange(filesToAdd);
+        }
+
+        public void Clear()
+        {
+            _files.Clear();
+            _data.Clear();
+            _text = null;
+        }
+
+        public bool ContainsData(string format)
+        {
+            return _data.ContainsKey(format);
+        }
+
+        public bool ContainsText()
+        {
+            return _text is not null;
+        }
+
+        public void Flush()
+        {
+            //It is a no-op because how should it be implemented/tested?
+        }
+
+        public object GetData(string format)
+        {
+            if (format is null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            if (!_data.ContainsKey(format))
+            {
+                return null;
+            }
+
+            return _data[format];
+        }
+
+        public IReadOnlyList<string> GetFileDropList()
+        {
+            return _files.AsReadOnly();
+        }
+
+        public string GetText()
+        {
+            if (string.IsNullOrEmpty(_text))
+            {
+                return string.Empty;
+            }
+
+            return _text;
+        }
+
+        public void SetData(string format, object data)
+        {
+            if (data is System.IO.Stream stream)
+            {
+                var copiedData = new System.IO.MemoryStream();
+                stream.CopyTo(copiedData);
+                copiedData.Seek(0, System.IO.SeekOrigin.Begin);
+                _data[format] = copiedData;
+                return;
+            }
+
+            _data[format] = data;
+        }
+    }
+}

--- a/Tests/AnnoDesigner.Core.Tests/Mocks/MockedClipboard.cs
+++ b/Tests/AnnoDesigner.Core.Tests/Mocks/MockedClipboard.cs
@@ -67,6 +67,11 @@ namespace AnnoDesigner.Core.Tests.Mocks
             return _text;
         }
 
+        public void SetText(string text)
+        {
+            _text = text;
+        }
+
         public void SetData(string format, object data)
         {
             if (data is System.IO.Stream stream)

--- a/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
+++ b/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
@@ -133,7 +133,6 @@ namespace AnnoDesigner.Tests
             Assert.False(viewModel.IsBusy);
 
             Assert.Null(viewModel.StatusMessage);
-            Assert.Null(viewModel.StatusMessageClipboard);
 
             Assert.NotNull(viewModel.AvailableIcons);
             Assert.NotNull(viewModel.SelectedIcon);


### PR DESCRIPTION
Implemented pasting from Windows clipboard. Supported sources:
- .ad file
- .ad file's string content
- old copy/paste functionality