### PR TITLE
Add option to hide version on exported image

### DIFF
--- a/AnnoDesigner.Core/Models/IAppSettings.cs
+++ b/AnnoDesigner.Core/Models/IAppSettings.cs
@@ -56,5 +56,6 @@ namespace AnnoDesigner.Core.Models
         bool InvertScrollingDirection { get; set; }
         bool ShowScrollbars { get; set; }
         bool IncludeRoadsInStatisticCalculation { get; set; }
+        bool RenderVersionOnExportedImageValue { get; set; }
     }
 }

--- a/AnnoDesigner/Localization/Localization.cs
+++ b/AnnoDesigner/Localization/Localization.cs
@@ -255,7 +255,8 @@ namespace AnnoDesigner.Localization
                     ["GeneralPreferencesIncludeRoadsInStatisticCalculation"] = "Include roads in statistics",
                     ["ShowMultipleInstanceWarning"] = "Show warning if multiple instances are open",
                     ["WarningMultipleInstancesAreRunning"] = "There is an update, but the app is open multiple times. Close all instances and start just 1 instance to allow the update to work.",
-                    ["SelectAllSameIdentifier"] = "Select all buildings of same type"
+                    ["SelectAllSameIdentifier"] = "Select all buildings of same type",
+                    ["RenderVersionOnExportedImage"] = "Render version on exported image"
                 },
                 ["ger"] = new Dictionary<string, string>()
                 {
@@ -458,7 +459,8 @@ namespace AnnoDesigner.Localization
                     ["GeneralPreferencesIncludeRoadsInStatisticCalculation"] = "Straßen in die Statistik einbeziehen",
                     ["ShowMultipleInstanceWarning"] = "Warnung anzeigen, wenn mehrere Instanzen geöffnet sind",
                     ["WarningMultipleInstancesAreRunning"] = "Es gibt ein Update, aber die App ist mehrfach geöffnet. Schließen Sie alle Instanzen und starten Sie nur 1 Instanz, damit das Update funktioniert.",
-                    ["SelectAllSameIdentifier"] = "Alle Gebäude desselben Typs auswählen"
+                    ["SelectAllSameIdentifier"] = "Alle Gebäude desselben Typs auswählen",
+                    ["RenderVersionOnExportedImage"] = "Zeige Layoutversion auf exportiertem Bild an"
                 },
                 ["fra"] = new Dictionary<string, string>()
                 {
@@ -661,7 +663,8 @@ namespace AnnoDesigner.Localization
                     ["GeneralPreferencesIncludeRoadsInStatisticCalculation"] = "Inclure les routes dans les statistiques",
                     ["ShowMultipleInstanceWarning"] = "Afficher un avertissement si plusieurs instances sont ouvertes",
                     ["WarningMultipleInstancesAreRunning"] = "Il y a une mise à jour, mais l'application est ouverte plusieurs fois. Fermez toutes les instances et démarrez une seule instance pour permettre à la mise à jour de fonctionner.",
-                    ["SelectAllSameIdentifier"] = "Sélectionner tous les bâtiments de même type"
+                    ["SelectAllSameIdentifier"] = "Sélectionner tous les bâtiments de même type",
+                    ["RenderVersionOnExportedImage"] = "Version du rendu sur l'image exportée"
                 },
                 ["esp"] = new Dictionary<string, string>()
                 {
@@ -864,7 +867,8 @@ namespace AnnoDesigner.Localization
                     ["GeneralPreferencesIncludeRoadsInStatisticCalculation"] = "Incluir las carreteras en las estadísticas",
                     ["ShowMultipleInstanceWarning"] = "Mostrar advertencia si hay varias instancias abiertas",
                     ["WarningMultipleInstancesAreRunning"] = "Hay una actualización, pero la aplicación está abierta varias veces. Cierra todas las instancias e inicia solo una para que la actualización funcione.",
-                    ["SelectAllSameIdentifier"] = "Seleccionar todos los edificios del mismo tipo"
+                    ["SelectAllSameIdentifier"] = "Seleccionar todos los edificios del mismo tipo",
+                    ["RenderVersionOnExportedImage"] = "Versión de renderizado en la imagen exportada"
                 },
                 ["pol"] = new Dictionary<string, string>()
                 {
@@ -1067,7 +1071,8 @@ namespace AnnoDesigner.Localization
                     ["GeneralPreferencesIncludeRoadsInStatisticCalculation"] = "Uwzględnienie dróg w statystykach",
                     ["ShowMultipleInstanceWarning"] = "Pokaż ostrzeżenie, jeśli otwartych jest wiele instancji",
                     ["WarningMultipleInstancesAreRunning"] = "Jest aktualizacja, ale aplikacja jest otwarta wiele razy. Zamknij wszystkie instancje i uruchom tylko 1 instancję, aby umożliwić działanie aktualizacji.",
-                    ["SelectAllSameIdentifier"] = "Wybierz wszystkie budynki tego samego typu"
+                    ["SelectAllSameIdentifier"] = "Wybierz wszystkie budynki tego samego typu",
+                    ["RenderVersionOnExportedImage"] = "Wersja renderowania na wyeksportowanym obrazie"
                 },
                 ["rus"] = new Dictionary<string, string>()
                 {
@@ -1270,7 +1275,8 @@ namespace AnnoDesigner.Localization
                     ["GeneralPreferencesIncludeRoadsInStatisticCalculation"] = "Включить дороги в статистику",
                     ["ShowMultipleInstanceWarning"] = "Показывать предупреждение, если открыто несколько экземпляров",
                     ["WarningMultipleInstancesAreRunning"] = "Есть обновление, но приложение открыто несколько раз. Закройте все экземпляры и запустите только 1 экземпляр, чтобы обновление сработало.",
-                    ["SelectAllSameIdentifier"] = "Выберите все здания одного типа"
+                    ["SelectAllSameIdentifier"] = "Выберите все здания одного типа",
+                    ["RenderVersionOnExportedImage"] = "Версия рендеринга на экспортированном изображении"
                 },
             };
 

--- a/AnnoDesigner/MainWindow.xaml
+++ b/AnnoDesigner/MainWindow.xaml
@@ -128,6 +128,9 @@
                     <MenuItem Header="{l:Localize RenderSelectionHighlightsOnExportedImage}"
                               IsCheckable="True"
                               IsChecked="{Binding RenderSelectionHighlightsOnExportedImageValue}" />
+                    <MenuItem Header="{l:Localize RenderVersionOnExportedImage}"
+                              IsCheckable="True"
+                              IsChecked="{Binding RenderVersionOnExportedImageValue}" />
                 </MenuItem>
                 <MenuItem Header="{l:Localize Language}"
                           TabIndex="23"

--- a/AnnoDesigner/Models/AppSettings.cs
+++ b/AnnoDesigner/Models/AppSettings.cs
@@ -105,6 +105,12 @@ namespace AnnoDesigner.Models
             set => Settings.Default.RenderSelectionHighlightsOnExportedImageValue = value;
         }
 
+        public bool RenderVersionOnExportedImageValue
+        {
+            get => Settings.Default.RenderVersionOnExportedImageValue;
+            set => Settings.Default.RenderVersionOnExportedImageValue = value;
+        }
+
         public bool ShowLabels
         {
             get => Settings.Default.ShowLabels;

--- a/AnnoDesigner/Properties/Settings.Designer.cs
+++ b/AnnoDesigner/Properties/Settings.Designer.cs
@@ -559,5 +559,17 @@ namespace AnnoDesigner.Properties {
                 this["ShowMultipleInstanceWarning"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool RenderVersionOnExportedImageValue {
+            get {
+                return ((bool)(this["RenderVersionOnExportedImageValue"]));
+            }
+            set {
+                this["RenderVersionOnExportedImageValue"] = value;
+            }
+        }
     }
 }

--- a/AnnoDesigner/Properties/Settings.settings
+++ b/AnnoDesigner/Properties/Settings.settings
@@ -137,5 +137,8 @@
     <Setting Name="ShowMultipleInstanceWarning" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="RenderVersionOnExportedImageValue" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AnnoDesigner/ViewModels/MainViewModel.cs
+++ b/AnnoDesigner/ViewModels/MainViewModel.cs
@@ -68,6 +68,7 @@ namespace AnnoDesigner.ViewModels
         private bool _canvasShowPanorama;
         private bool _useCurrentZoomOnExportedImageValue;
         private bool _renderSelectionHighlightsOnExportedImageValue;
+        private bool _renderVersionOnExportedImageValue;
         private bool _isLanguageChange;
         private bool _isBusy;
         private string _statusMessage;
@@ -602,6 +603,7 @@ namespace AnnoDesigner.ViewModels
 
             UseCurrentZoomOnExportedImageValue = _appSettings.UseCurrentZoomOnExportedImageValue;
             RenderSelectionHighlightsOnExportedImageValue = _appSettings.RenderSelectionHighlightsOnExportedImageValue;
+            RenderVersionOnExportedImageValue = _appSettings.RenderVersionOnExportedImageValue;
 
             CanvasShowGrid = _appSettings.ShowGrid;
             CanvasShowIcons = _appSettings.ShowIcons;
@@ -642,6 +644,7 @@ namespace AnnoDesigner.ViewModels
 
             _appSettings.UseCurrentZoomOnExportedImageValue = UseCurrentZoomOnExportedImageValue;
             _appSettings.RenderSelectionHighlightsOnExportedImageValue = RenderSelectionHighlightsOnExportedImageValue;
+            _appSettings.RenderVersionOnExportedImageValue = RenderVersionOnExportedImageValue;
 
             string savedTreeState;
             savedTreeState = SerializationHelper.SaveToJsonString(PresetsTreeViewModel.GetCondensedTreeState());
@@ -967,6 +970,12 @@ namespace AnnoDesigner.ViewModels
             set { UpdateProperty(ref _renderSelectionHighlightsOnExportedImageValue, value); }
         }
 
+        public bool RenderVersionOnExportedImageValue
+        {
+            get { return _renderVersionOnExportedImageValue; }
+            set { UpdateProperty(ref _renderVersionOnExportedImageValue, value); }
+        }
+
         public bool IsLanguageChange
         {
             get { return _isLanguageChange; }
@@ -1271,7 +1280,7 @@ namespace AnnoDesigner.ViewModels
 
         private void ExecuteExportImage(object param)
         {
-            ExecuteExportImageSub(UseCurrentZoomOnExportedImageValue, RenderSelectionHighlightsOnExportedImageValue);
+            ExecuteExportImageSub(UseCurrentZoomOnExportedImageValue, RenderSelectionHighlightsOnExportedImageValue, RenderVersionOnExportedImageValue);
         }
 
         /// <summary>
@@ -1279,7 +1288,7 @@ namespace AnnoDesigner.ViewModels
         /// </summary>
         /// <param name="exportZoom">indicates whether the current zoom level should be applied, if false the default zoom is used</param>
         /// <param name="exportSelection">indicates whether selection and influence highlights should be rendered</param>
-        private void ExecuteExportImageSub(bool exportZoom, bool exportSelection)
+        private void ExecuteExportImageSub(bool exportZoom, bool exportSelection, bool exportVersion)
         {
             var dialog = new SaveFileDialog
             {
@@ -1297,7 +1306,7 @@ namespace AnnoDesigner.ViewModels
             {
                 try
                 {
-                    RenderToFile(dialog.FileName, 1, exportZoom, exportSelection, StatisticsViewModel.IsVisible);
+                    RenderToFile(dialog.FileName, 1, exportZoom, exportSelection, StatisticsViewModel.IsVisible, exportVersion);
 
                     _messageBoxService.ShowMessage(Application.Current.MainWindow,
                        _localizationHelper.GetLocalization("ExportImageSuccessful"),
@@ -1320,7 +1329,7 @@ namespace AnnoDesigner.ViewModels
         /// <param name="border">normalization value used prior to exporting</param>
         /// <param name="exportZoom">indicates whether the current zoom level should be applied, if false the default zoom is used</param>
         /// <param name="exportSelection">indicates whether selection and influence highlights should be rendered</param>
-        private void RenderToFile(string filename, int border, bool exportZoom, bool exportSelection, bool renderStatistics, bool renderVersion = true)
+        private void RenderToFile(string filename, int border, bool exportZoom, bool exportSelection, bool renderStatistics, bool renderVersion)
         {
             if (AnnoCanvas.PlacedObjects.Count() == 0)
             {

--- a/AnnoDesigner/app.config
+++ b/AnnoDesigner/app.config
@@ -147,6 +147,9 @@
             <setting name="ShowMultipleInstanceWarning" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="RenderVersionOnExportedImageValue" serializeAs="String">
+                <value>True</value>
+            </setting>
         </AnnoDesigner.Properties.Settings>
     </userSettings>
     <applicationSettings>

--- a/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
+++ b/Tests/AnnoDesigner.Tests/MainViewModelTests.cs
@@ -492,6 +492,26 @@ namespace AnnoDesigner.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public void SaveSettings_IsCalled_ShouldSaveRenderVersionOnExportedImageValue(bool expectedRenderVersionOnExportedImageValue)
+        {
+            // Arrange            
+            var appSettings = new Mock<IAppSettings>();
+            appSettings.SetupAllProperties();
+
+            var viewModel = GetViewModel(null, appSettings.Object);
+            viewModel.RenderVersionOnExportedImageValue = expectedRenderVersionOnExportedImageValue;
+
+            // Act
+            viewModel.SaveSettings();
+
+            // Assert
+            Assert.Equal(expectedRenderVersionOnExportedImageValue, appSettings.Object.RenderVersionOnExportedImageValue);
+            appSettings.Verify(x => x.Save(), Times.AtLeastOnce);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void SaveSettings_IsCalled_ShouldSaveIsPavedStreet(bool expectedIsPavedStreet)
         {
             // Arrange            
@@ -867,6 +887,26 @@ namespace AnnoDesigner.Tests
 
             // Assert
             Assert.Equal(expectedRenderSelectionHighlightsOnExportedImageValue, viewModel.RenderSelectionHighlightsOnExportedImageValue);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void LoadSettings_IsCalled_ShouldLoadRenderVersionOnExportedImageValue(bool expectedRenderVersionOnExportedImageValue)
+        {
+            // Arrange            
+            var appSettings = new Mock<IAppSettings>();
+            appSettings.SetupAllProperties();
+            appSettings.Setup(x => x.RenderVersionOnExportedImageValue).Returns(() => expectedRenderVersionOnExportedImageValue);
+
+            var viewModel = GetViewModel(null, appSettings.Object);
+            viewModel.RenderVersionOnExportedImageValue = !expectedRenderVersionOnExportedImageValue;
+
+            // Act
+            viewModel.LoadSettings();
+
+            // Assert
+            Assert.Equal(expectedRenderVersionOnExportedImageValue, viewModel.RenderVersionOnExportedImageValue);
         }
 
         [Theory]


### PR DESCRIPTION
This PR fixes #411.
Because the option is also available via command line it is made available via the menu.

- [x] menu is localized
- [x] tests added for loading/saving the settings