### PR TITLE
Fix: default layout version was not set

### DIFF
--- a/AnnoDesigner/ViewModels/LayoutSettingsViewModel.cs
+++ b/AnnoDesigner/ViewModels/LayoutSettingsViewModel.cs
@@ -17,6 +17,11 @@ namespace AnnoDesigner.ViewModels
             get { return _layoutVersion; }
             set
             {
+                if (value is null)
+                {
+                    return;
+                }
+
                 UpdateProperty(ref _layoutVersion, value);
                 OnPropertyChanged(nameof(LayoutVersionDisplayValue));
             }


### PR DESCRIPTION
This PR fixes the default version of a layout if an old layout was loaded.
Prior to this PR the entry filed for the layout version was empty.